### PR TITLE
Adds support for ResembleAI

### DIFF
--- a/hypertts_addon/services/service_resemble.py
+++ b/hypertts_addon/services/service_resemble.py
@@ -1,0 +1,74 @@
+from typing import Dict
+import requests
+import base64
+from hypertts_addon import service, voice, constants, logging_utils
+
+logger = logging_utils.get_child_logger(__name__)
+
+class ResembleAI(service.ServiceBase):
+    # https://docs.app.resemble.ai/docs/text_to_speech/
+    API_ENDPOINT = "https://f.cluster.resemble.ai/synthesize"
+    CONFIG_API_KEY = 'resemble_api_key'
+
+    # --- Service Properties ---
+    def __init__(self):
+        service.ServiceBase.__init__(self)
+
+    @property
+    def service_name(self) -> str:
+        return "ResembleAI"
+
+    @property
+    def service_type(self) -> constants.ServiceType:
+        return constants.ServiceType.tts
+
+    @property
+    def service_fee(self) -> constants.ServiceFee:
+        return constants.ServiceFee.paid
+
+    def configuration_options(self):
+        return {
+            self.CONFIG_API_KEY: str
+        }
+
+    def configure(self, config):
+        self._config = config
+        self.api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
+
+    def voice_list(self):
+        return self.basic_voice_list()
+
+    # --- TTS Core Logic ---
+    def get_tts_audio(self, source_text: str, voice_info: voice.VoiceBase, voice_options_override: Dict):
+        voice_uuid = voice_info.voice_key['uuid']
+
+        output_format = voice_options_override.get('output_format', 'mp3')
+        sample_rate = voice_options_override.get('sample_rate')
+        precision = voice_options_override.get('precision')
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "voice_uuid": voice_uuid,
+            "data": source_text,
+            "output_format": output_format
+        }
+
+        if sample_rate:
+            payload["sample_rate"] = int(sample_rate)
+        if output_format == 'wav' and precision:
+            payload["precision"] = precision
+
+        logger.debug(f"ResembleAI synthesis with {payload}")
+        response = requests.post(self.API_ENDPOINT, json=payload, headers=headers)
+        response_data = response.json()
+
+        # https://docs.app.resemble.ai/docs/getting_started/errors
+        if not response_data.get("success"):
+            raise RuntimeError(f"ResembleAI synthesis failed: {response_data.get('message')}")
+
+        audio_bytes = base64.b64decode(response_data["audio_content"])
+        return audio_bytes

--- a/hypertts_addon/services/voicelist.py
+++ b/hypertts_addon/services/voicelist.py
@@ -5,6 +5,120 @@ from .. import constants
 from .. import languages
 from .. import voice
 
+RESEMBLE_SUPPORTED_LANGUAGES = [
+    languages.AudioLanguage.af_ZA,
+    languages.AudioLanguage.am_ET,
+    languages.AudioLanguage.ar_AE,
+    languages.AudioLanguage.ar_EG,
+    languages.AudioLanguage.ar_IQ,
+    languages.AudioLanguage.ar_KW,
+    languages.AudioLanguage.ar_MA,
+    languages.AudioLanguage.ar_QA,
+    languages.AudioLanguage.ar_SA,
+    languages.AudioLanguage.az_AZ,
+    languages.AudioLanguage.bg_BG,
+    languages.AudioLanguage.bn_BD,
+    languages.AudioLanguage.bn_IN,
+    languages.AudioLanguage.bs_BA,
+    languages.AudioLanguage.ca_ES,
+    languages.AudioLanguage.zh_CN,
+    languages.AudioLanguage.cs_CZ,
+    languages.AudioLanguage.da_DK,
+    languages.AudioLanguage.de_DE,
+    languages.AudioLanguage.el_GR,
+    languages.AudioLanguage.en_AU,
+    languages.AudioLanguage.en_CA,
+    languages.AudioLanguage.en_GB,
+    languages.AudioLanguage.en_HK,
+    languages.AudioLanguage.en_IE,
+    languages.AudioLanguage.en_IN,
+    languages.AudioLanguage.en_KE,
+    languages.AudioLanguage.en_NZ,
+    languages.AudioLanguage.en_SG,
+    languages.AudioLanguage.en_US,
+    languages.AudioLanguage.en_ZA,
+    languages.AudioLanguage.es_AR,
+    languages.AudioLanguage.es_CL,
+    languages.AudioLanguage.es_CO,
+    languages.AudioLanguage.es_CR,
+    languages.AudioLanguage.es_CU,
+    languages.AudioLanguage.es_DO,
+    languages.AudioLanguage.es_EC,
+    languages.AudioLanguage.es_ES,
+    languages.AudioLanguage.es_MX,
+    languages.AudioLanguage.es_PE,
+    languages.AudioLanguage.es_PR,
+    languages.AudioLanguage.es_PY,
+    languages.AudioLanguage.es_US,
+    languages.AudioLanguage.es_VE,
+    languages.AudioLanguage.et_EE,
+    languages.AudioLanguage.eu_ES,
+    languages.AudioLanguage.fa_IR,
+    languages.AudioLanguage.fi_FI,
+    languages.AudioLanguage.fil_PH,
+    languages.AudioLanguage.fr_BE,
+    languages.AudioLanguage.fr_CA,
+    languages.AudioLanguage.fr_CH,
+    languages.AudioLanguage.fr_FR,
+    languages.AudioLanguage.ga_IE,
+    languages.AudioLanguage.gu_IN,
+    languages.AudioLanguage.he_IL,
+    languages.AudioLanguage.hi_IN,
+    languages.AudioLanguage.hr_HR,
+    languages.AudioLanguage.hu_HU,
+    languages.AudioLanguage.hy_AM,
+    languages.AudioLanguage.id_ID,
+    languages.AudioLanguage.is_IS,
+    languages.AudioLanguage.it_IT,
+    languages.AudioLanguage.ja_JP,
+    languages.AudioLanguage.jv_ID,
+    languages.AudioLanguage.kk_KZ,
+    languages.AudioLanguage.km_KH,
+    languages.AudioLanguage.kn_IN,
+    languages.AudioLanguage.ko_KR,
+    languages.AudioLanguage.lt_LT,
+    languages.AudioLanguage.lv_LV,
+    languages.AudioLanguage.ml_IN,
+    languages.AudioLanguage.mn_MN,
+    languages.AudioLanguage.mr_IN,
+    languages.AudioLanguage.ms_MY,
+    languages.AudioLanguage.mt_MT,
+    languages.AudioLanguage.my_MM,
+    languages.AudioLanguage.nb_NO,
+    languages.AudioLanguage.ne_NP,
+    languages.AudioLanguage.nl_BE,
+    languages.AudioLanguage.nl_NL,
+    languages.AudioLanguage.pa_IN,
+    languages.AudioLanguage.pl_PL,
+    languages.AudioLanguage.ps_AF,
+    languages.AudioLanguage.pt_BR,
+    languages.AudioLanguage.pt_PT,
+    languages.AudioLanguage.ro_RO,
+    languages.AudioLanguage.ru_RU,
+    languages.AudioLanguage.si_LK,
+    languages.AudioLanguage.sk_SK,
+    languages.AudioLanguage.sl_SI,
+    languages.AudioLanguage.so_SO,
+    languages.AudioLanguage.sq_AL,
+    languages.AudioLanguage.sr_RS,
+    languages.AudioLanguage.sv_SE,
+    languages.AudioLanguage.sw_KE,
+    languages.AudioLanguage.ta_IN,
+    languages.AudioLanguage.ta_LK,
+    languages.AudioLanguage.ta_MY,
+    languages.AudioLanguage.te_IN,
+    languages.AudioLanguage.th_TH,
+    languages.AudioLanguage.tr_TR,
+    languages.AudioLanguage.uk_UA,
+    languages.AudioLanguage.ur_PK,
+    languages.AudioLanguage.vi_VN,
+    languages.AudioLanguage.zh_CN,
+    languages.AudioLanguage.zh_HK,
+    languages.AudioLanguage.zh_TW,
+    languages.AudioLanguage.yue_CN,
+    languages.AudioLanguage.zu_ZA
+]
+
 VOICE_LIST = [
         
         voice.TtsVoice_v3(
@@ -35703,4 +35817,1399 @@ VOICE_LIST = [
             ],
             service_fee=constants.ServiceFee.paid
         )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose',
+            voice_key={'uuid': 'b6b59389'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Alex',
+            voice_key={'uuid': '41b99669'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Amelia',
+            voice_key={'uuid': 'ecbe5d97'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Charlotte',
+            voice_key={'uuid': '96b91cf9'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Ash',
+            voice_key={'uuid': 'ee322483'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Luna',
+            voice_key={'uuid': 'ae8223ca'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Aurora',
+            voice_key={'uuid': 'a72d9fca'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Cliff',
+            voice_key={'uuid': 'fcf8490c'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Orion',
+            voice_key={'uuid': 'aa8053cc'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Ember',
+            voice_key={'uuid': '55592656'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Sam',
+            voice_key={'uuid': '0f2f9a7e'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Tyler',
+            voice_key={'uuid': 'ff225977'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Vicky',
+            voice_key={'uuid': 'f453b918'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Olga',
+            voice_key={'uuid': '07c1d6b5'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Little Brittle',
+            voice_key={'uuid': '8a73f115'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Niki',
+            voice_key={'uuid': 'db37643c'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Little Ari',
+            voice_key={'uuid': '805adead'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Blade',
+            voice_key={'uuid': '8bedd793'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Rico',
+            voice_key={'uuid': '14ca34b3'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Arthur',
+            voice_key={'uuid': '9de11312'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Pete',
+            voice_key={'uuid': '1864fd63'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Tanja (Excited)',
+            voice_key={'uuid': '9a594e05'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Tanja',
+            voice_key={'uuid': 'adb84c77'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Annika',
+            voice_key={'uuid': 'b27f3cc0'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='John',
+            voice_key={'uuid': 'ac48daeb'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Matt Weller',
+            voice_key={'uuid': 'f4da4639'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Kessi',
+            voice_key={'uuid': '2211cb8c'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Ken',
+            voice_key={'uuid': '3dbfbf3d'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Brandy Sky',
+            voice_key={'uuid': '79e2f1dc'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Britney',
+            voice_key={'uuid': 'e57e23ff'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Brenley',
+            voice_key={'uuid': 'e6ec3ca4'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Hem',
+            voice_key={'uuid': 'b6edbe5f'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Kate',
+            voice_key={'uuid': '28b4cc5a'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Harry Robinson',
+            voice_key={'uuid': '3c36d67d'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='William (Whispering)',
+            voice_key={'uuid': 'e2180df0'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Maureen',
+            voice_key={'uuid': '7d94218f'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Chris Whiting',
+            voice_key={'uuid': '95b7560a'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Siobhan',
+            voice_key={'uuid': 'af72c1ac'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Lothar',
+            voice_key={'uuid': '78671217'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Tarkos',
+            voice_key={'uuid': '779842bf'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Katya',
+            voice_key={'uuid': 'c9ee13b4'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Helena',
+            voice_key={'uuid': 'ac948df2'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Connor',
+            voice_key={'uuid': 'a6131acf'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Julie Hoverson',
+            voice_key={'uuid': 'b119524c'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Justin (Meditative) (Legacy)',
+            voice_key={'uuid': '93ce0920'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Justin (Meditative)',
+            voice_key={'uuid': '2570000e'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Samantha (Legacy)',
+            voice_key={'uuid': '266bfae9'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Samantha',
+            voice_key={'uuid': 'e28236ee'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Olivia (Legacy)',
+            voice_key={'uuid': '405b58e3'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Olivia',
+            voice_key={'uuid': 'ef49f972'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Charles (Legacy)',
+            voice_key={'uuid': '4c6d3da5'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Charles',
+            voice_key={'uuid': 'd79a5198'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Seth (Legacy)',
+            voice_key={'uuid': 'a52c4efc'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Seth',
+            voice_key={'uuid': 'd3e61caf'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Melody (Legacy)',
+            voice_key={'uuid': '15be93bd'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Melody',
+            voice_key={'uuid': '1c49e774'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose (Whispering) (Legacy)',
+            voice_key={'uuid': 'a56c5c6f'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose (Whispering)',
+            voice_key={'uuid': '28fcdf76'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose (Legacy)',
+            voice_key={'uuid': '7c8e47ca'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose',
+            voice_key={'uuid': '33eecc17'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Beth (Legacy)',
+            voice_key={'uuid': '25c7823f'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Beth',
+            voice_key={'uuid': 'fa66d263'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose (Winded) (Legacy)',
+            voice_key={'uuid': '6f9a77a4'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Primrose (Winded)',
+            voice_key={'uuid': '0097f246'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Vivian (Legacy)',
+            voice_key={'uuid': 'bed1044d'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Vivian',
+            voice_key={'uuid': '1ff0045f'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Justin (Legacy)',
+            voice_key={'uuid': 'b2d1bb75'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Justin',
+            voice_key={'uuid': '9d513c17'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Paula J',
+            voice_key={'uuid': '33e64cd2'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Willow II (Whispering)',
+            voice_key={'uuid': 'c815cd7a'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Ed Smart',
+            voice_key={'uuid': '0c755526'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='William (Whispering) (Legacy)',
+            voice_key={'uuid': '79eb7953'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='William (Whispering)',
+            voice_key={'uuid': 'f2906c4a'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Josh',
+            voice_key={'uuid': '987c99e9'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Liz',
+            voice_key={'uuid': '4884d94a'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Carl Bishop (Angry)',
+            voice_key={'uuid': 'f06cd770'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Austin',
+            voice_key={'uuid': '82a67e58'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Carl Bishop (Scared) (Legacy)',
+            voice_key={'uuid': '1dcf0222'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Beatrice Pendergast',
+            voice_key={'uuid': '00b1fd4e'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Tanja (Warm Word Weaver)',
+            voice_key={'uuid': 'abbbc383'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Richard Garifo',
+            voice_key={'uuid': '85ba84f2'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Karl Nordman',
+            voice_key={'uuid': 'da67f17e'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Gene Amore',
+            voice_key={'uuid': 'f2ea7aa0'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Robert',
+            voice_key={'uuid': '3e907bcc'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Tanja (Telephonic)',
+            voice_key={'uuid': '4f5a470b'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Adam Lofbomm',
+            voice_key={'uuid': '4e228dba'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='David',
+            voice_key={'uuid': '5bb13f03'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Carl Bishop',
+            voice_key={'uuid': '01bcc102'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Steve (Scared)',
+            voice_key={'uuid': 'aaa56e79'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Radio Nikole',
+            voice_key={'uuid': '19eae884'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Broadcast Joe',
+            voice_key={'uuid': '21e49584'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Mike',
+            voice_key={'uuid': '3a02dc40'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
+,
+    voice.TtsVoice_v3(
+
+            name='Deanna',
+            voice_key={'uuid': '0842fdf9'},
+            options={
+                'output_format': {'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'},
+                'sample_rate': {'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'},
+                'precision': {'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}
+            },
+            service='ResembleAI',
+            gender=constants.Gender.Any,
+            audio_languages=RESEMBLE_SUPPORTED_LANGUAGES,
+            service_fee=constants.ServiceFee.paid
+    )
 ]


### PR DESCRIPTION
Adds support for https://www.resemble.ai/

Not sure if the UUIDs for the standard voices are different for every user. I converted them to python code with the following script

```python
import os
import requests
import json
import re
import textwrap
from typing import List, Dict, Any, Optional

# Original source of language list: https://resemble.notion.site/Localize-Language-Support-List-e80e955c273b4acf81894031fc5c62dd
# Hardcoded language data as provided
RAW_LANGUAGE_DATA = [
    "1. Afrikaans - South Africa: 'af-za'",
    "2. Amharic - Ethiopia: 'am-et'",
    "3. Arabic - United Arab Emirates: 'ar-ae'",
    "4. Arabic - Egypt: 'ar-eg'",
    "5. Arabic - Iraq: 'ar-iq'",
    "6. Arabic - Kuwait: 'ar-kw'",
    "7. Arabic - Morocco: 'ar-ma'",
    "8. Arabic - Qatar: 'ar-qa'",
    "9. Arabic - Saudi Arabia: 'ar-sa'",
    "10. Azerbaijani - Azerbaijan: 'az-az'",
    "11. Bulgarian - Bulgaria: 'bg-bg'",
    "12. Bengali - Bangladesh: 'bn-bd'",
    "13. Bengali - India: 'bn-in'",
    "14. Bosnian - Bosnia: 'bs-ba'",
    "15. Catalan - Spain: 'ca-es'",
    "16. Mandarin - China: 'cmn-cn'",
    "17. Czech - Czech Republic: 'cs-cz'",
    "18. Danish - Denmark: 'da-dk'",
    "19. German - Germany: 'de-de'",
    "20. Greek - Greece: 'el-gr'",
    "21. English - Australia: 'en-au'",
    "22. English - Canada: 'en-ca'",
    "23. English - United Kingdom: 'en-gb'",
    "24. English - Hong Kong: 'en-hk'",
    "25. English - Ireland: 'en-ie'",
    "26. English - India: 'en-in'",
    "27. English - Kenya: 'en-ke'",
    "28. English - New Zealand: 'en-nz'",
    "29. English - Singapore: 'en-sg'",
    "30. English - United States: 'en-us'",
    "31. English - South Africa: 'en-za'",
    "32. Spanish - Argentina: 'es-ar'",
    "33. Spanish - Chile: 'es-cl'",
    "34. Spanish - Colombia: 'es-co'",
    "35. Spanish - Costa Rica: 'es-cr'",
    "36. Spanish - Cuba: 'es-cu'",
    "37. Spanish - Dominican Republic: 'es-do'",
    "38. Spanish - Ecuador: 'es-ec'",
    "39. Spanish - Spain: 'es-es'",
    "40. Spanish - Mexico: 'es-mx'",
    "41. Spanish - Peru: 'es-pe'",
    "42. Spanish - Puerto Rico: 'es-pr'",
    "43. Spanish - Paraguay: 'es-py'",
    "44. Spanish - United States: 'es-us'",
    "45. Spanish - Venezuela: 'es-ve'",
    "46. Estonian - Estonia: 'et-ee'",
    "47. Basque - Spain: 'eu-es'",
    "48. Persian - Iran: 'fa-ir'",
    "49. Finnish - Finland: 'fi-fi'", # Duplicate in provided list, kept one
    "50. Filipino - Philippines: 'fil-ph'",
    "51. French - Belgium: 'fr-be'",
    "52. French - Canada: 'fr-ca'",
    "53. French - Switzerland: 'fr-ch'",
    "54. French - France: 'fr-fr'",
    "55. Irish - Ireland: 'ga-ie'",
    "56. Gujarati - India: 'gu-in'",
    "57. Hebrew - Israel: 'he-il'",
    "58. Hindi - India: 'hi-in'",
    "59. Croatian - Croatia: 'hr-hr'",
    "60. Hungarian - Hungary: 'hu-hu'",
    "61. Armenian - Armenia: 'hy-am'",
    "62. Indonesian - Indonesia: 'id-id'",
    "63. Icelandic - Iceland: 'is-is'",
    "64. Italian - Italy: 'it-it'",
    "65. Japanese - Japan: 'ja-jp'",
    "66. Javanese - Indonesia: 'jv-id'",
    "67. Kazakh - Kazakhstan: 'kk-kz'",
    "68. Khmer - Cambodia: 'km-kh'",
    "69. Kannada - India: 'kn-in'",
    "70. Korean - South Korea: 'ko-kr'",
    "71. Lithuanian - Lithuania: 'lt-lt'",
    "72. Latvian - Latvia: 'lv-lv'",
    "73. Malayalam - India: 'ml-in'",
    "74. Mongolian - Mongolia: 'mn-mn'",
    "75. Marathi - India: 'mr-in'",
    "76. Malay - Malaysia: 'ms-my'",
    "77. Maltese - Malta: 'mt-mt'",
    "78. Burmese - Myanmar: 'my-mm'",
    "79. Norwegian - Norway: 'nb-no'",
    "80. Nepali - Nepal: 'ne-np'",
    "81. Dutch - Belgium: 'nl-be'",
    "82. Dutch - Netherlands: 'nl-nl'",
    "83. Punjabi - India: 'pa-in'",
    "84. Polish - Poland: 'pl-pl'",
    "85. Pashto - Afghanistan: 'ps-af'",
    "86. Portuguese - Brazil: 'pt-br'",
    "87. Portuguese - Portugal: 'pt-pt'",
    "88. Romanian - Romania: 'ro-ro'",
    "89. Russian - Russia: 'ru-ru'",
    "90. Sinhala - Sri Lanka: 'si-lk'",
    "91. Slovak - Slovakia: 'sk-sk'",
    "92. Slovenian - Slovenia: 'sl-si'",
    "93. Somali - Somalia: 'so-so'",
    "94. Albanian - Albania: 'sq-al'",
    "95. Serbian - Serbia: 'sr-rs'",
    "96. Swedish - Sweden: 'sv-se'",
    "97. Swahili - Kenya: 'sw-ke'",
    "98. Tamil - India: 'ta-in'",
    "99. Tamil - Sri Lanka: 'ta-lk'",
    "100. Tamil - Malaysia: 'ta-my'",
    "101. Telugu - India: 'te-in'",
    "102. Thai - Thailand: 'th-th'",
    "103. Turkish - Turkey: 'tr-tr'",
    "104. Ukrainian - Ukraine: 'uk-ua'",
    "105. Urdu - Pakistan: 'ur-pk'",
    "106. Vietnamese - Vietnam: 'vi-vn'",
    "107. Chinese - China: 'zh-cn'",
    "108. Chinese - Hong Kong: 'zh-hk'",
    "109. Chinese - Taiwan: 'zh-tw'",
    "110. Chinese - Mandarin: 'yue-cn'", # Note: 'yue-cn' typically Cantonese, mapped as per instruction
    "111. Zulu - South Africa: 'zu-za'"
]

def map_raw_to_audio_language_enum(raw_language_entry_str: str) -> Optional[str]:
    """
    Transforms a raw language string (e.g., "1. Afrikaans - South Africa: 'af-za'")
    into its corresponding AudioLanguage enum string format (e.g., "AudioLanguage.af_ZA").
    """
    match = re.search(r"'(.*?)'", raw_language_entry_str)
    if not match:
        print(f"Warning: Could not parse language code from: {raw_language_entry_str}")
        return None
    
    clean_code: str = match.group(1)

    if clean_code == 'cmn-cn':
        return "languages.AudioLanguage.zh_CN"
    elif clean_code == 'yue-cn': # As per instruction, mapping 'yue-cn' to AudioLanguage.yue_CN
        return "languages.AudioLanguage.yue_CN"
    
    parts: List[str] = clean_code.split('-')
    if len(parts) == 2:
        lang_part: str = parts[0]
        region_part: str = parts[1].upper()
        return f"languages.AudioLanguage.{lang_part}_{region_part}"
    elif len(parts) == 1: # For codes like 'la' if they were to appear
        return f"languages.AudioLanguage.{parts[0]}"
    else:
        print(f"Warning: Could not transform code: {clean_code} from entry: {raw_language_entry_str}")
        return None

def get_resemble_voices(api_key: str) -> Optional[List[Dict[str, Any]]]:
    """
    Fetches voice data from the Resemble AI API.
    """
    url: str = "https://app.resemble.ai/api/v2/voices?page=1&page_size=1000" # Corrected page_size
    headers: Dict[str, str] = {'Authorization': f'Bearer {api_key}'}
    
    try:
        response: requests.Response = requests.get(url, headers=headers, timeout=30)
        response.raise_for_status() # Raises an HTTPError for bad responses (4XX or 5XX)
        response_data: Dict[str, Any] = response.json()
        
        if response_data.get('success') is True:
            return response_data.get('items', [])
        else:
            print(f"API call unsuccessful. Response: {response_data.get('message', 'No message provided.')}")
            return None
    except requests.exceptions.RequestException as e:
        print(f"Error fetching voices from Resemble AI API: {e}")
        return None
    except json.JSONDecodeError:
        print("Error decoding JSON response from Resemble AI API.")
        return None

def generate_voice_config_snippets(voices_list: List[Dict[str, Any]], audio_languages_ref_name: str) -> List[str]:
    """
    Generates Python code snippets for TtsVoice_v3 configurations.
    """
    generated_python_code: List[str] = []

    for voice_info in voices_list:
        name: Optional[str] = voice_info.get('name')
        uuid: Optional[str] = voice_info.get('uuid')

        if not name or not uuid:
            print(f"Warning: Skipping voice due to missing name or uuid: {voice_info}")
            continue

        # Escape single quotes in name if any, to prevent breaking the Python string
        safe_name: str = name.replace("'", "\\'")

        # Raw snippet with base indentation for parameters
        raw_snippet_body = f"""
    name='{safe_name}',
    voice_key={{'uuid': '{uuid}'}},
    options={{
        'output_format': {{'type': 'list', 'values': ['mp3', 'wav'], 'default': 'mp3'}},
        'sample_rate': {{'type': 'list', 'values': ['8000', '16000', '22050', '32000', '44100'], 'default': '44100'}},
        'precision': {{'type': 'list', 'values': ['MULAW', 'PCM_16', 'PCM_24', 'PCM_32'], 'default': 'PCM_32'}}
    }},
    service='ResembleAI',
    gender=constants.Gender.Any,
    audio_languages={audio_languages_ref_name},
    service_fee=constants.ServiceFee.paid"""

        # Indent the body by 8 spaces (4 for voice.TtsVoice_v3 + 4 for parameters)
        indented_body = textwrap.indent(raw_snippet_body, "        ")
        
        # Construct the full snippet with voice.TtsVoice_v3 indented by 4 spaces
        full_snippet = f"    voice.TtsVoice_v3(\n{indented_body}\n    )"
        generated_python_code.append(full_snippet)
        
    return generated_python_code

def main() -> None:
    # Phase 1: Language List Processing
    target_audio_languages: List[str] = []
    for entry in RAW_LANGUAGE_DATA:
        enum_str: Optional[str] = map_raw_to_audio_language_enum(entry)
        if enum_str:
            target_audio_languages.append(enum_str)
    
    if not target_audio_languages:
        print("Error: No audio languages could be processed. Aborting.")
        return

    # Phase 2: Fetch Voices from Resemble AI API
    api_key: Optional[str] = os.environ.get('RESEMBLE_API_KEY')
    if not api_key:
        print("Error: RESEMBLE_API_KEY environment variable not set. Aborting.")
        return

    voices_list: Optional[List[Dict[str, Any]]] = get_resemble_voices(api_key)
    if voices_list is None: # Indicates an error occurred during fetching or processing
        print("Error: Could not retrieve voices from Resemble AI. Aborting.")
        return
    if not voices_list:
        print("No voices found or API call returned an empty list.")
        # For now, let's print an empty list if no voices.
    
    # Phase 3 & 4: Define RESEMBLE_SUPPORTED_LANGUAGES constant, Generate Snippets, and Output
    print("# --- Generated Resemble AI Voice Configurations ---")
    print("# Ensure 'voice' and 'constants' modules are imported where this list is used.")
    print("# Example: from your_tts_module import voice, constants")
    print("# Example: from hypertts_addon.languages import AudioLanguage # If AudioLanguage enum is needed directly")
    print("")
    print("# Define the list of supported languages once")
    print("RESEMBLE_SUPPORTED_LANGUAGES = [")
    if target_audio_languages:
        for i, lang_str in enumerate(target_audio_languages):
            # Assuming lang_str is like "AudioLanguage.en_US"
            print(f"    {lang_str}{',' if i < len(target_audio_languages) - 1 else ''}")
    print("]")
    print("")
    
    # Pass the NAME of the constant to the generation function
    generated_code_snippets: List[str] = generate_voice_config_snippets(voices_list, "RESEMBLE_SUPPORTED_LANGUAGES")

    print("generated_resemble_ai_voices: List[Any] = [ # Assuming TtsVoice_v3 returns some type")
    if generated_code_snippets:
        print("\n,\n".join(generated_code_snippets))
    print("]")
    print("\n# --- End of Generated Configurations ---")

if __name__ == "__main__":
    main()
```


At least for Greek, the API requires a `lang` tag, otherwise the text will be pronounced American. I added a `lang` tag using Text Replacement Rules

| Type  | Pattern  | Replacement                                       |
|-------|----------|---------------------------------------------------|
| Regex | `"^(.*)$"` | `"<speak><lang xml:lang="el-gr">\1</lang></speak>"` |