### PR TITLE
Fix template regex escape warnings

### DIFF
--- a/hypertts_addon/text_utils.py
+++ b/hypertts_addon/text_utils.py
@@ -12,8 +12,8 @@ from . import logging_utils
 logger = logging_utils.get_child_logger(__name__)
 
 
-REGEXP_REALTIME_SIMPLE_TEMPLATE = '.*<hypertts-template\s+setting="(.*)"\s+version="([a-z1-9]*)"[^>]*>(.*)</hypertts-template>.*'
-REGEXP_REALTIME_ADVANCED_TEMPLATE = '.*<hypertts-template-advanced\s+setting="(.*)"\s+version="([a-z1-9]*)"[^>]*>\n(.*)</hypertts-template-advanced>.*'
+REGEXP_REALTIME_SIMPLE_TEMPLATE = '.*<hypertts-template\\s+setting="(.*)"\\s+version="([a-z1-9]*)"[^>]*>(.*)</hypertts-template>.*'
+REGEXP_REALTIME_ADVANCED_TEMPLATE = '.*<hypertts-template-advanced\\s+setting="(.*)"\\s+version="([a-z1-9]*)"[^>]*>\n(.*)</hypertts-template-advanced>.*'
 
 # convert characters which are problematic on SSML TTS APIs
 SSML_CONVERSION_MAP ={


### PR DESCRIPTION
## Summary

- Escape the `\s` regex sequences in the realtime template patterns.
- Preserve the existing newline matching behavior for advanced templates while avoiding Python 3.13+ `SyntaxWarning` messages on Anki startup.

Fixes #347.

## Validation

- `git diff --check HEAD~1..HEAD`

Not run locally.