### PR TITLE
Add transcript JSON generation for ElevenLabs and Google

### DIFF
--- a/hypertts_addon/component_target.py
+++ b/hypertts_addon/component_target.py
@@ -19,6 +19,8 @@ class BatchTarget(component_common.ConfigComponentBase):
 
         # initialize widgets
         self.target_field_combobox = aqt.qt.QComboBox()
+        self.transcript_field_combobox = aqt.qt.QComboBox()
+        self.transcript_checkbox = aqt.qt.QCheckBox('Write transcript JSON to field')
         # text and sound
         self.text_sound_group = aqt.qt.QButtonGroup()
         self.radio_button_sound_only = aqt.qt.QRadioButton('Sound Tag only')
@@ -46,6 +48,7 @@ class BatchTarget(component_common.ConfigComponentBase):
         self.radio_button_sound_only.setChecked(not self.batch_target_model.text_and_sound_tag)
         self.radio_button_remove_sound.setChecked(self.batch_target_model.remove_sound_tag)
         self.radio_button_keep_sound.setChecked(not self.batch_target_model.remove_sound_tag)
+        self.load_transcript_field()
 
         # ensure model at the higher level gets updated
         # this is important for example if the target field doesn't exist in the field list, we want to make
@@ -97,6 +100,8 @@ class BatchTarget(component_common.ConfigComponentBase):
         groupbox.setLayout(vlayout)
         self.batch_target_layout.addWidget(groupbox)                
 
+        self.batch_target_layout.addWidget(self.draw_transcript_groupbox())
+
         self.batch_target_layout.addStretch()
 
         # connect events
@@ -115,6 +120,8 @@ class BatchTarget(component_common.ConfigComponentBase):
         self.radio_button_text_sound.toggled.connect(self.update_text_sound)
         self.radio_button_remove_sound.toggled.connect(self.update_remove_sound)
         self.radio_button_keep_sound.toggled.connect(self.update_remove_sound)
+        self.transcript_checkbox.toggled.connect(self.update_transcript_field)
+        self.transcript_field_combobox.currentIndexChanged.connect(lambda x: self.update_transcript_field())
 
     def update_text_sound(self):
         self.batch_target_model.text_and_sound_tag = self.radio_button_text_sound.isChecked()
@@ -128,6 +135,36 @@ class BatchTarget(component_common.ConfigComponentBase):
         logger.info('update_field')
         self.batch_target_model.target_field = self.field_list[self.target_field_combobox.currentIndex()]
         self.notify_model_update()
+
+    def draw_transcript_groupbox(self):
+        groupbox = aqt.qt.QGroupBox('Transcript JSON')
+        vlayout = aqt.qt.QVBoxLayout()
+        vlayout.addWidget(self.transcript_checkbox)
+        self.transcript_field_combobox.addItems(self.field_list)
+        vlayout.addWidget(self.transcript_field_combobox)
+        groupbox.setLayout(vlayout)
+        self.update_transcript_visibility()
+        return groupbox
+
+    def load_transcript_field(self):
+        transcript_field = self.batch_target_model.transcript_field
+        self.transcript_checkbox.setChecked(transcript_field not in [None, ''])
+        if transcript_field in self.field_list:
+            self.transcript_field_combobox.setCurrentText(transcript_field)
+        self.update_transcript_visibility()
+
+    def update_transcript_field(self):
+        if not self.transcript_checkbox.isChecked():
+            self.batch_target_model.transcript_field = None
+            self.update_transcript_visibility()
+            self.notify_model_update()
+            return
+        self.batch_target_model.transcript_field = self.field_list[self.transcript_field_combobox.currentIndex()]
+        self.update_transcript_visibility()
+        self.notify_model_update()
+
+    def update_transcript_visibility(self):
+        self.transcript_field_combobox.setEnabled(self.transcript_checkbox.isChecked())
 
     def notify_model_update(self):
         self.model_change_callback(self.batch_target_model)

--- a/hypertts_addon/component_target_easy.py
+++ b/hypertts_addon/component_target_easy.py
@@ -80,6 +80,7 @@ class BatchTargetEasy(component_target.BatchTarget):
         sound_options_layout.addWidget(sound_tag_container)
 
         self.batch_target_layout.addWidget(self.sound_options_widget)
+        self.batch_target_layout.addWidget(self.draw_transcript_groupbox())
         self.batch_target_layout.addStretch()
 
         # Set initial state
@@ -160,4 +161,5 @@ class BatchTargetEasy(component_target.BatchTarget):
         self.radio_button_sound_only.setChecked(not model.text_and_sound_tag)
         self.radio_button_remove_sound.setChecked(model.remove_sound_tag)
         self.radio_button_keep_sound.setChecked(not model.remove_sound_tag)
+        self.load_transcript_field()
 

--- a/hypertts_addon/config_models.py
+++ b/hypertts_addon/config_models.py
@@ -137,6 +137,7 @@ class BatchTarget():
     remove_sound_tag: bool = True
     insert_location: InsertLocation = InsertLocation.AFTER
     same_field: bool = False
+    transcript_field: Optional[str] = None
 
     def serialize(self):
         return serialize_batch_target(self)

--- a/hypertts_addon/hypertts.py
+++ b/hypertts_addon/hypertts.py
@@ -121,7 +121,11 @@ class HyperTTS():
             source_text = self.get_source_text(note, batch.source, text_override)
             processed_text = self.process_text(source_text, batch.text_processing)
 
-        full_filename, audio_filename = self.get_audio_file(processed_text, batch.voice_selection, audio_request_context)
+        full_filename, audio_filename, transcript_json = self.get_note_audio_artifacts(
+            processed_text,
+            batch,
+            audio_request_context
+        )
         sound_tag, sound_file = self.get_collection_sound_tag(full_filename, audio_filename)
 
         target_field_content = note[target_field]
@@ -142,11 +146,31 @@ class HyperTTS():
 
         logger.debug(f'setting note[{target_field}] to {target_field_content}')
         note[target_field] = target_field_content
+        self.set_note_transcript(batch, note, transcript_json)
         if not add_mode:
             with _start_span(op="db.anki.note.update", name="update_note"):
                 anki_collection.update_note(note)
 
         return source_text, processed_text, sound_file, full_filename
+
+    def get_note_audio_artifacts(self, processed_text, batch, audio_request_context):
+        transcript_field = batch.target.transcript_field
+        if transcript_field == None or len(transcript_field) == 0:
+            full_filename, audio_filename = self.get_audio_file(
+                processed_text,
+                batch.voice_selection,
+                audio_request_context
+            )
+            return full_filename, audio_filename, None
+        return self.get_audio_file_transcript(processed_text, batch.voice_selection, audio_request_context)
+
+    def set_note_transcript(self, batch, note, transcript_json):
+        transcript_field = batch.target.transcript_field
+        if transcript_field == None or len(transcript_field) == 0:
+            return
+        if transcript_field not in note:
+            raise errors.TargetFieldNotFoundError(transcript_field)
+        note[transcript_field] = transcript_json
 
     def get_note_audio(self, batch, note, audio_request_context, text_override):
         source_text = self.get_source_text(note, batch.source, text_override)
@@ -163,6 +187,18 @@ class HyperTTS():
         return self.get_audio_file(processed_text, realtime_model.voice_selection, context.AudioRequestContext(constants.AudioRequestReason.realtime))
 
     def get_audio_file(self, processed_text, voice_selection, audio_request_context):
+        full_filename, audio_filename, _ = self.get_audio_file_optional_transcript(
+            processed_text,
+            voice_selection,
+            audio_request_context,
+            False
+        )
+        return full_filename, audio_filename
+
+    def get_audio_file_transcript(self, processed_text, voice_selection, audio_request_context):
+        return self.get_audio_file_optional_transcript(processed_text, voice_selection, audio_request_context, True)
+
+    def get_audio_file_optional_transcript(self, processed_text, voice_selection, audio_request_context, include_transcript):
         # sanity checks
         if voice_selection.selection_mode in [constants.VoiceSelectionMode.priority, constants.VoiceSelectionMode.random]:
             if len(voice_selection.voice_list) == 0:
@@ -184,11 +220,16 @@ class HyperTTS():
                 assert isinstance(voice_id, voice_module.TtsVoiceId_v3), \
                     f"Expected voice_id to be TtsVoiceId_v3, got {type(voice_id).__name__}, voice_with_options: {type(voice_with_options).__name__}"
 
-                full_filename, audio_filename = self.generate_audio_write_file(processed_text, 
-                    voice_with_options.voice_id, voice_with_options.options, audio_request_context)
+                full_filename, audio_filename, transcript_json = self.generate_audio_write_file(
+                    processed_text,
+                    voice_with_options.voice_id,
+                    voice_with_options.options,
+                    audio_request_context,
+                    include_transcript
+                )
                 logger.debug(f'finished generating audio file and write to file for {processed_text}')
                 self.config_register_added_audio()
-                return full_filename, audio_filename
+                return full_filename, audio_filename, transcript_json
             except errors.AudioNotFoundError as exc:
                 # try the next voice, as long as one is available
                 if not priority_mode:
@@ -448,7 +489,7 @@ class HyperTTS():
     # processing of sound tags / collection stuff
     # ===========================================
 
-    def generate_audio_write_file(self, source_text, voice_id: voice_module.TtsVoiceId_v3, voice_options, audio_request_context):
+    def generate_audio_write_file(self, source_text, voice_id: voice_module.TtsVoiceId_v3, voice_options, audio_request_context, include_transcript=False):
         assert isinstance(voice_id, voice_module.TtsVoiceId_v3), f"Expected voice_id to be TtsVoiceId_v3, got {type(voice_id).__name__}"
         format = options.AudioFormat.mp3 # default to mp3
         if options.AUDIO_FORMAT_PARAMETER in voice_options:
@@ -460,7 +501,7 @@ class HyperTTS():
             audio_filename = self.get_audio_filename(hash_str, format)
             full_filename = self.get_full_audio_file_name(hash_str, format)
             logger.info(f'requesting audio for hash {hash_str}, full filename {full_filename}')
-            cache_hit = os.path.exists(full_filename) and os.path.getsize(full_filename) > 0
+            cache_hit = os.path.exists(full_filename) and os.path.getsize(full_filename) > 0 and not include_transcript
             if span is not None:
                 span.set_data("cache_hit", cache_hit)
         if not cache_hit:
@@ -470,7 +511,13 @@ class HyperTTS():
                 voice = self.service_manager.locate_voice(voice_id)
             logger.info(f'located voice: {voice}')
 
-            audio_data = self.service_manager.get_tts_audio(source_text, voice, voice_options, audio_request_context)
+            audio_data, transcript_json = self.get_audio_data_transcript(
+                source_text,
+                voice,
+                voice_options,
+                audio_request_context,
+                include_transcript
+            )
             logger.info(f'not found in cache, requesting')
             logger.debug(f'opening {full_filename}')
             with _start_span(op="file.write", name="write_audio_to_user_files") as span:
@@ -482,8 +529,16 @@ class HyperTTS():
                 logger.debug(f'wrote audio data')
                 f.close()
         else:
+            transcript_json = None
             logger.info(f'file exists in cache')
-        return full_filename, audio_filename
+        return full_filename, audio_filename, transcript_json
+
+    def get_audio_data_transcript(self, source_text, voice, voice_options, audio_request_context, include_transcript):
+        if not include_transcript:
+            audio_data = self.service_manager.get_tts_audio(source_text, voice, voice_options, audio_request_context)
+            return audio_data, None
+        result = self.service_manager.get_tts_audio_transcript(source_text, voice, voice_options, audio_request_context)
+        return result.audio, result.transcript_json
 
     def get_collection_sound_tag(self, full_filename, audio_filename):
         with _start_span(op="db.anki.media.add", name="media_add_file"):

--- a/hypertts_addon/service.py
+++ b/hypertts_addon/service.py
@@ -70,6 +70,16 @@ class ServiceBase(abc.ABC):
     def get_tts_audio(self, source_text, voice: voice_module.TtsVoice_v3, options):
         pass
 
+    def supports_tts_transcript(self):
+        return False
+
+    def get_tts_audio_transcript(self, source_text, voice: voice_module.TtsVoice_v3, options):
+        raise errors.RequestError(
+            source_text,
+            voice,
+            f'{self.name}: transcript generation is not supported for voice {voice.name}'
+        )
+
 
     # some helper functions
     def basic_voice_list(self) -> typing.List[voice_module.TtsVoice_v3]:

--- a/hypertts_addon/servicemanager.py
+++ b/hypertts_addon/servicemanager.py
@@ -167,6 +167,15 @@ class ServiceManager():
         else:
             return self.get_tts_audio_implementation(source_text, voice, options, audio_request_context)
 
+    def get_tts_audio_transcript(self, source_text, voice: voice_module.TtsVoice_v3, options, audio_request_context):
+        logger.debug(f'get_tts_audio_transcript for voice: {voice}')
+        assert isinstance(voice, voice_module.TtsVoice_v3), f"Expected voice to be TtsVoice_v3, got {type(voice).__name__}"
+        if self.use_cloud_language_tools(voice):
+            error_message = f'{voice.service}: transcript generation is not supported through Cloud Language Tools'
+            raise errors.RequestError(source_text, voice, error_message)
+        service_instance = self.services[voice.service]
+        return self._get_tts_audio_transcript_service(service_instance, source_text, voice, options)
+
     def get_tts_audio_instrumented(self, source_text, voice: voice_module.TtsVoice_v3, options, audio_request_context):
         with sentry_sdk.new_scope() as sentry_scope:
             # inside this scope, we can set tags and context which will get unwound when this scope closes
@@ -309,6 +318,22 @@ class ServiceManager():
             # so this is a permanent configuration error. Previously it fell
             # through to the generic handler below and was mis-classified as
             # the retryable UnknownServiceError.
+            raise errors.ServicePermissionError(source_text, voice,
+                f'Invalid credential / request header — check your API key for '
+                f'stray whitespace or newlines: {e}') from e
+        except requests.exceptions.ConnectionError as e:
+            raise errors.ServiceConnectionError(source_text, voice, str(e)) from e
+        except Exception as e:
+            raise errors.UnknownServiceError(source_text, voice, str(e)) from e
+
+    def _get_tts_audio_transcript_service(self, service_instance, source_text, voice, options):
+        try:
+            return service_instance.get_tts_audio_transcript(source_text, voice, options)
+        except errors.HyperTTSError:
+            raise
+        except requests.exceptions.Timeout as e:
+            raise errors.ServiceTimeoutError(source_text, voice, 'HTTP request timed out') from e
+        except requests.exceptions.InvalidHeader as e:
             raise errors.ServicePermissionError(source_text, voice,
                 f'Invalid credential / request header — check your API key for '
                 f'stray whitespace or newlines: {e}') from e

--- a/hypertts_addon/services/service_elevenlabs.py
+++ b/hypertts_addon/services/service_elevenlabs.py
@@ -7,6 +7,7 @@ from hypertts_addon import service
 from hypertts_addon import errors
 from hypertts_addon import constants
 from hypertts_addon import options
+from hypertts_addon import transcription
 from hypertts_addon import logging_utils
 logger = logging_utils.get_child_logger(__name__)
 
@@ -39,11 +40,26 @@ class ElevenLabs(service.ServiceBase):
     def voice_list(self):
         return self.basic_voice_list()
 
+    def supports_tts_transcript(self):
+        return True
+
     def get_tts_audio(self, source_text, voice: voice.VoiceBase, voice_options):
+        response = self.request_tts(source_text, voice, voice_options, False)
+        return response.content
+
+    def get_tts_audio_transcript(self, source_text, voice: voice.VoiceBase, voice_options):
+        response = self.request_tts(source_text, voice, voice_options, True)
+        response_data = response.json()
+        audio = transcription.decode_elevenlabs_audio(response_data)
+        segments = transcription.elevenlabs_alignment_to_segments(response_data)
+        return transcription.TtsAudioTranscript(audio, transcription.serialize_segments(segments))
+
+    def request_tts(self, source_text, voice: voice.VoiceBase, voice_options, with_timestamps):
         api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
 
         voice_id = voice.voice_key['voice_id']
-        url = f'https://api.elevenlabs.io/v1/text-to-speech/{voice_id}'
+        suffix = '/with-timestamps' if with_timestamps else ''
+        url = f'https://api.elevenlabs.io/v1/text-to-speech/{voice_id}{suffix}'
 
         # Handle audio format
         audio_format_str = voice_options.get(options.AUDIO_FORMAT_PARAMETER, voice.options.get(options.AUDIO_FORMAT_PARAMETER, {}).get('default', 'mp3'))
@@ -51,7 +67,7 @@ class ElevenLabs(service.ServiceBase):
             url += '?output_format=opus_48000_192'
 
         headers = {
-            "Accept": "audio/mpeg",
+            "Accept": "application/json" if with_timestamps else "audio/mpeg",
             "xi-api-key": api_key
         }
 
@@ -82,4 +98,4 @@ class ElevenLabs(service.ServiceBase):
                 raise errors.ServicePermissionError(source_text, voice, error_message)
             raise errors.RequestError(source_text, voice, error_message)
 
-        return response.content
+        return response

--- a/hypertts_addon/services/service_google.py
+++ b/hypertts_addon/services/service_google.py
@@ -9,6 +9,7 @@ from hypertts_addon import service
 from hypertts_addon import errors
 from hypertts_addon import constants
 from hypertts_addon import options
+from hypertts_addon import transcription
 from hypertts_addon import logging_utils
 logger = logging_utils.get_child_logger(__name__)
 
@@ -41,7 +42,25 @@ class Google(service.ServiceBase):
     def voice_list(self):
         return self.basic_voice_list()
 
+    def supports_tts_transcript(self):
+        return True
+
     def get_tts_audio(self, source_text, voice: voice.VoiceBase, voice_options):
+        response_data = self.request_tts(source_text, voice, voice_options, None)
+        encoded = response_data['audioContent']
+        return base64.b64decode(encoded)
+
+    def get_tts_audio_transcript(self, source_text, voice: voice.VoiceBase, voice_options):
+        if 'Chirp' in voice.voice_key['name']:
+            error_message = f'{self.name}: transcript generation requires SSML, got Chirp voice {voice.voice_key["name"]}'
+            raise errors.RequestError(source_text, voice, error_message)
+        marked_text = transcription.build_marked_ssml(source_text)
+        response_data = self.request_tts(source_text, voice, voice_options, marked_text.ssml)
+        audio = base64.b64decode(response_data['audioContent'])
+        segments = transcription.google_timepoints_to_segments(marked_text.words, response_data.get('timepoints', []))
+        return transcription.TtsAudioTranscript(audio, transcription.serialize_segments(segments))
+
+    def request_tts(self, source_text, voice: voice.VoiceBase, voice_options, marked_ssml):
         # configuration options
         api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
         is_explorer_api_key = self.get_configuration_value_optional(self.CONFIG_EXPLORER_API_KEY, False)
@@ -57,9 +76,7 @@ class Google(service.ServiceBase):
             options.AudioFormat.ogg_opus: 'OGG_OPUS'
         }
 
-        input_ssml = {
-            "ssml": f"<speak>{source_text}</speak>"
-        }
+        input_ssml = {"ssml": marked_ssml or f"<speak>{source_text}</speak>"}
         input_text = {
             "text": source_text
         }
@@ -83,6 +100,8 @@ class Google(service.ServiceBase):
                 "name": voice.voice_key['name'],
             }
         }
+        if marked_ssml:
+            payload["enableTimePointing"] = ["SSML_MARK"]
 
         logger.debug(f'requesting audio with payload {payload}')
 
@@ -109,8 +128,4 @@ class Google(service.ServiceBase):
                 raise errors.ServicePermissionError(source_text, voice, error_message)
             raise errors.RequestError(source_text, voice, error_message)
 
-        data = response.json()
-        encoded = data['audioContent']
-        audio_content = base64.b64decode(encoded)
-
-        return audio_content
+        return response.json()

--- a/hypertts_addon/transcription.py
+++ b/hypertts_addon/transcription.py
@@ -1,0 +1,123 @@
+import base64
+import html
+import json
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+
+@dataclass
+class TranscriptSegment:
+    s: float
+    e: float
+    w: str
+
+
+@dataclass
+class TtsAudioTranscript:
+    audio: bytes
+    transcript_json: Optional[str] = None
+
+
+@dataclass
+class SsmlMarkedText:
+    ssml: str
+    words: List[str]
+
+
+def serialize_segments(segments: List[TranscriptSegment]) -> str:
+    """Serialize transcript segments for Anki fields.
+
+    Example: serialize_segments([TranscriptSegment(0, 0.2, 'hello')])
+    """
+    return json.dumps(
+        [{'s': segment.s, 'e': segment.e, 'w': segment.w} for segment in segments],
+        ensure_ascii=False,
+        separators=(',', ':'),
+    )
+
+
+def decode_elevenlabs_audio(response_data) -> bytes:
+    """Decode ElevenLabs timestamp response audio.
+
+    Example: decode_elevenlabs_audio({'audio_base64': '...'})
+    """
+    encoded = response_data.get('audio_base64')
+    if not encoded:
+        raise ValueError(f"audio_base64 missing in ElevenLabs response {response_data}; expected response with audio_base64")
+    return base64.b64decode(encoded)
+
+
+def elevenlabs_alignment_to_segments(response_data) -> List[TranscriptSegment]:
+    """Convert ElevenLabs character alignment to word segments.
+
+    Example: elevenlabs_alignment_to_segments({'alignment': {...}})
+    """
+    alignment = response_data.get('normalized_alignment') or response_data.get('alignment')
+    if not alignment:
+        raise ValueError(f"alignment missing in ElevenLabs response {response_data}; expected alignment or normalized_alignment")
+    characters = alignment['characters']
+    starts = alignment['character_start_times_seconds']
+    ends = alignment['character_end_times_seconds']
+    return character_alignment_to_segments(characters, starts, ends)
+
+
+def character_alignment_to_segments(characters: Sequence[str], starts: Sequence[float], ends: Sequence[float]) -> List[TranscriptSegment]:
+    """Group character timestamps into word segments.
+
+    Example: character_alignment_to_segments(['h', 'i'], [0, 0.1], [0.1, 0.2])
+    """
+    segments = []
+    word_chars = []
+    word_start = None
+    word_end = None
+    for index, character in enumerate(characters):
+        if character.isspace():
+            _append_segment(segments, word_chars, word_start, word_end)
+            word_chars = []
+            word_start = None
+            word_end = None
+            continue
+        if word_start is None:
+            word_start = starts[index]
+        word_end = ends[index]
+        word_chars.append(character)
+    _append_segment(segments, word_chars, word_start, word_end)
+    return segments
+
+
+def _append_segment(segments, word_chars, word_start, word_end):
+    if not word_chars:
+        return
+    segments.append(TranscriptSegment(round(word_start, 3), round(word_end, 3), ''.join(word_chars)))
+
+
+def build_marked_ssml(source_text: str) -> SsmlMarkedText:
+    """Build SSML marks before each word and at the end.
+
+    Example: build_marked_ssml('hello world')
+    """
+    words = re.findall(r'\S+', source_text)
+    if not words:
+        raise ValueError(f"source_text has no words for SSML marks: {source_text!r}; expected non-empty text")
+    marked_words = []
+    for index, word in enumerate(words):
+        marked_words.append(f'<mark name="w{index}"/>{html.escape(word)}')
+    marked_words.append(f'<mark name="w{len(words)}"/>')
+    return SsmlMarkedText(f"<speak>{' '.join(marked_words)}</speak>", words)
+
+
+def google_timepoints_to_segments(words, timepoints) -> List[TranscriptSegment]:
+    """Convert Google SSML mark timepoints to word segments.
+
+    Example: google_timepoints_to_segments(['hello'], [{'markName': 'w0', 'timeSeconds': 0}, {'markName': 'w1', 'timeSeconds': 0.2}])
+    """
+    time_by_mark = {timepoint['markName']: timepoint['timeSeconds'] for timepoint in timepoints}
+    segments = []
+    for index, word in enumerate(words):
+        start_mark = f'w{index}'
+        end_mark = f'w{index + 1}'
+        if start_mark not in time_by_mark or end_mark not in time_by_mark:
+            raise ValueError(f"missing Google timepoint marks for word {word!r}: {timepoints}; expected marks {start_mark} and {end_mark}")
+        segments.append(TranscriptSegment(round(time_by_mark[start_mark], 3), round(time_by_mark[end_mark], 3), word))
+    return segments

--- a/tests/test_audio_batch.py
+++ b/tests/test_audio_batch.py
@@ -6,6 +6,7 @@ from test_utils import testing_utils
 from hypertts_addon import constants
 from hypertts_addon import config_models
 from hypertts_addon import batch_status
+from hypertts_addon import transcription
 from hypertts_addon import logging_utils
 
 logger = logging_utils.get_test_child_logger(__name__)
@@ -124,6 +125,32 @@ def test_simple_1(qtbot):
     # verify batch error manager stats
     assert batch_status_obj[0].sound_file != None
     assert batch_status_obj[1].sound_file != None
+
+def test_simple_with_transcript_field(qtbot):
+    config_gen = testing_utils.TestConfigGenerator()
+    hypertts_instance = config_gen.build_hypertts_instance_test_servicemanager('default')
+    mock_collection = testing_utils.MockCollection()
+
+    voice_a_1 = get_default_voice_id(hypertts_instance)
+    single = config_models.VoiceSelectionSingle()
+    single.set_voice(config_models.VoiceWithOptions(voice_a_1, {'speed': 42}))
+
+    batch = config_models.BatchConfig(hypertts_instance.anki_utils)
+    batch.set_source(config_models.BatchSource(mode=constants.BatchMode.simple, source_field='Chinese'))
+    batch.set_target(config_models.BatchTarget('Sound', False, True, transcript_field='Pinyin'))
+    batch.set_voice_selection(single)
+    batch.set_text_processing(config_models.TextProcessing())
+
+    transcript_result = transcription.TtsAudioTranscript(b'mock audio', '[{"s":0,"e":0.2,"w":"hello"}]')
+    hypertts_instance.service_manager.get_tts_audio_transcript = lambda source_text, voice, options, context: transcript_result
+
+    listener = MockBatchStatusListener(hypertts_instance.anki_utils)
+    batch_status_obj = batch_status.BatchStatus(hypertts_instance.anki_utils, [config_gen.note_id_1], listener)
+    hypertts_instance.process_batch_audio([config_gen.note_id_1], batch, batch_status_obj, mock_collection)
+
+    note_1 = hypertts_instance.anki_utils.get_note_by_id(config_gen.note_id_1)
+    assert note_1.set_values['Pinyin'] == '[{"s":0,"e":0.2,"w":"hello"}]'
+    assert 'Sound' in note_1.set_values
 
 def test_simple_text_processing(qtbot):
     # create batch configuration

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -385,7 +385,8 @@ class ConfigModelsTests(unittest.TestCase):
                 'text_and_sound_tag': False,
                 'remove_sound_tag': False,
                 'insert_location': 'AFTER',
-                'same_field': False
+                'same_field': False,
+                'transcript_field': None
             },
             'voice_selection': {
                 'voice_selection_mode': 'single',
@@ -452,7 +453,8 @@ class ConfigModelsTests(unittest.TestCase):
                     'text_and_sound_tag': text_and_sound_tag,
                     'remove_sound_tag': remove_sound_tag,
                     'insert_location': 'AFTER',
-                    'same_field': False
+                    'same_field': False,
+                    'transcript_field': None
                 }
                 assert batch_config.serialize()['target'] == expected_output
 
@@ -473,6 +475,7 @@ class ConfigModelsTests(unittest.TestCase):
         self.assertEqual(batch_target.remove_sound_tag, True)
         self.assertEqual(batch_target.insert_location, config_models.InsertLocation.AFTER)
         self.assertEqual(batch_target.same_field, False)
+        self.assertEqual(batch_target.transcript_field, None)
 
 
     def test_batch_config_target_deserialize_schema_v4(self):
@@ -490,6 +493,7 @@ class ConfigModelsTests(unittest.TestCase):
         self.assertEqual(batch_target.remove_sound_tag, True)
         self.assertEqual(batch_target.insert_location, config_models.InsertLocation.CURSOR_LOCATION)
         self.assertEqual(batch_target.same_field, True)
+        self.assertEqual(batch_target.transcript_field, None)
 
 
     def test_text_processing(self):
@@ -764,7 +768,8 @@ class ConfigModelsTests(unittest.TestCase):
                 'text_and_sound_tag': False,
                 'remove_sound_tag': False,
                 'insert_location': 'AFTER',
-                'same_field': False
+                'same_field': False,
+                'transcript_field': None
             },
             'voice_selection': {
                 'voice_selection_mode': 'single',

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,112 @@
+import base64
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hypertts_addon import constants
+from hypertts_addon import transcription
+from hypertts_addon.languages import AudioLanguage
+from hypertts_addon import voice as voice_module
+from hypertts_addon.services.service_elevenlabs import ElevenLabs
+from hypertts_addon.services.service_google import Google
+
+
+class TranscriptionTests(unittest.TestCase):
+    def test_character_alignment_to_segments(self):
+        segments = transcription.character_alignment_to_segments(
+            list('Hello world'),
+            [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.7, 0.8, 0.9, 1.0, 1.1],
+            [0.1, 0.2, 0.3, 0.4, 0.5, 0.5, 0.8, 0.9, 1.0, 1.1, 1.2],
+        )
+
+        self.assertEqual(transcription.serialize_segments(segments), '[{"s":0,"e":0.5,"w":"Hello"},{"s":0.7,"e":1.2,"w":"world"}]')
+
+    def test_build_marked_ssml(self):
+        marked_text = transcription.build_marked_ssml('Hello <world>')
+
+        self.assertEqual(marked_text.words, ['Hello', '<world>'])
+        self.assertEqual(marked_text.ssml, '<speak><mark name="w0"/>Hello <mark name="w1"/>&lt;world&gt; <mark name="w2"/></speak>')
+
+    def test_google_timepoints_to_segments(self):
+        segments = transcription.google_timepoints_to_segments(
+            ['Hello', 'world'],
+            [
+                {'markName': 'w0', 'timeSeconds': 0},
+                {'markName': 'w1', 'timeSeconds': 0.4},
+                {'markName': 'w2', 'timeSeconds': 0.9},
+            ],
+        )
+
+        self.assertEqual(transcription.serialize_segments(segments), '[{"s":0,"e":0.4,"w":"Hello"},{"s":0.4,"e":0.9,"w":"world"}]')
+
+
+class TranscriptServiceTests(unittest.TestCase):
+    def test_elevenlabs_get_tts_audio_transcript(self):
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        mock_voice = self.make_elevenlabs_voice()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            'audio_base64': base64.b64encode(b'audio').decode('ascii'),
+            'alignment': {
+                'characters': list('Hi there'),
+                'character_start_times_seconds': [0, 0.1, 0.2, 0.4, 0.5, 0.6, 0.7, 0.8],
+                'character_end_times_seconds': [0.1, 0.2, 0.2, 0.5, 0.6, 0.7, 0.8, 0.9],
+            },
+        }
+
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post', return_value=response) as post:
+            result = service.get_tts_audio_transcript('Hi there', mock_voice, {})
+
+        self.assertEqual(result.audio, b'audio')
+        self.assertEqual(result.transcript_json, '[{"s":0,"e":0.2,"w":"Hi"},{"s":0.4,"e":0.9,"w":"there"}]')
+        self.assertIn('/with-timestamps', post.call_args.args[0])
+
+    def test_google_get_tts_audio_transcript(self):
+        service = Google()
+        service.configure({'api_key': 'fake_key'})
+        mock_voice = self.make_google_voice()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            'audioContent': base64.b64encode(b'audio').decode('ascii'),
+            'timepoints': [
+                {'markName': 'w0', 'timeSeconds': 0},
+                {'markName': 'w1', 'timeSeconds': 0.3},
+                {'markName': 'w2', 'timeSeconds': 0.8},
+            ],
+        }
+
+        with patch('hypertts_addon.services.service_google.requests.post', return_value=response) as post:
+            result = service.get_tts_audio_transcript('Hi there', mock_voice, {})
+
+        payload = post.call_args.kwargs['json']
+        self.assertEqual(result.audio, b'audio')
+        self.assertEqual(result.transcript_json, '[{"s":0,"e":0.3,"w":"Hi"},{"s":0.3,"e":0.8,"w":"there"}]')
+        self.assertEqual(payload['enableTimePointing'], ['SSML_MARK'])
+        self.assertIn('<mark name="w0"/>Hi', payload['input']['ssml'])
+
+    def make_elevenlabs_voice(self):
+        return voice_module.TtsVoice_v3(
+            name='Test Voice',
+            voice_key={'voice_id': 'test_id', 'model_id': 'eleven_monolingual_v1'},
+            options={
+                'stability': {'default': 0.5},
+                'similarity_boost': {'default': 0.75},
+            },
+            service='ElevenLabs',
+            gender=constants.Gender.Male,
+            audio_languages=[AudioLanguage.en_US],
+            service_fee=constants.ServiceFee.paid,
+        )
+
+    def make_google_voice(self):
+        return voice_module.TtsVoice_v3(
+            name='en-US voice',
+            voice_key={'language_code': 'en-US', 'name': 'en-US-Neural2-A'},
+            options={'speaking_rate': {'default': 1.0}},
+            service='Google',
+            gender=constants.Gender.Female,
+            audio_languages=[AudioLanguage.en_US],
+            service_fee=constants.ServiceFee.paid,
+        )


### PR DESCRIPTION
## Summary
I use this add-on to generate audio for Anki cards, and some card templates can do a lot more when they also have transcript timing data. With a transcript JSON field, the card can highlight words while the audio plays and keep the text display cleaner. Since HyperTTS already handles the audio workflow well, this adds the missing piece directly to the preset flow. I can share an example card that uses this if helpful.

- Add optional transcript JSON generation for batch targets.
- Support ElevenLabs timestamp responses through `/with-timestamps`.
- Support Google Cloud Text-to-Speech timepoints by generating SSML word marks.
- Add UI controls for choosing the transcript destination field.

## Evidences

<img width="812" height="588" alt="{2876BE31-9106-45C1-A7CF-193501CB5F8B}" src="https://github.com/user-attachments/assets/4d790e18-b4c9-4ed5-b7b6-ef751cf4d651" />

<img width="1210" height="110" alt="{83790E88-781F-4A0B-B93C-7E46BCCA866C}" src="https://github.com/user-attachments/assets/6e989c80-443d-4b3c-bf36-a8a4bd031ecb" />

<img width="565" height="381" alt="Animação2" src="https://github.com/user-attachments/assets/73f78234-cfff-4b80-849b-c5840dcf3223" />
 
