### PR TITLE
Add opt-in searchable audio info span next to generated sound tags

### DIFF
--- a/hypertts_addon/component_target.py
+++ b/hypertts_addon/component_target.py
@@ -31,6 +31,8 @@ class BatchTarget(component_common.ConfigComponentBase):
         self.radio_button_keep_sound = aqt.qt.QRadioButton('Keep other sound tags (append)')
         self.remove_sound_group.addButton(self.radio_button_remove_sound)
         self.remove_sound_group.addButton(self.radio_button_keep_sound)
+        # searchable audio meta
+        self.checkbox_insert_audio_meta = aqt.qt.QCheckBox('Insert audio info')
 
 
     def get_model(self):
@@ -46,6 +48,7 @@ class BatchTarget(component_common.ConfigComponentBase):
         self.radio_button_sound_only.setChecked(not self.batch_target_model.text_and_sound_tag)
         self.radio_button_remove_sound.setChecked(self.batch_target_model.remove_sound_tag)
         self.radio_button_keep_sound.setChecked(not self.batch_target_model.remove_sound_tag)
+        self.checkbox_insert_audio_meta.setChecked(self.batch_target_model.insert_audio_meta)
 
         # ensure model at the higher level gets updated
         # this is important for example if the target field doesn't exist in the field list, we want to make
@@ -87,15 +90,26 @@ class BatchTarget(component_common.ConfigComponentBase):
         # remove sound tag
         # ================
         groupbox = aqt.qt.QGroupBox('Existing Sound Tag Handling')
-        vlayout = aqt.qt.QVBoxLayout()        
+        vlayout = aqt.qt.QVBoxLayout()
         label = aqt.qt.QLabel(constants.GUI_TEXT_TARGET_REMOVE_SOUND_TAG)
         label.setWordWrap(True)
-        vlayout.addWidget(label)        
+        vlayout.addWidget(label)
         self.radio_button_remove_sound.setChecked(True)
         vlayout.addWidget(self.radio_button_remove_sound)
         vlayout.addWidget(self.radio_button_keep_sound)
         groupbox.setLayout(vlayout)
-        self.batch_target_layout.addWidget(groupbox)                
+        self.batch_target_layout.addWidget(groupbox)
+
+        # searchable audio meta
+        # =====================
+        groupbox = aqt.qt.QGroupBox('Searchable Audio Info')
+        vlayout = aqt.qt.QVBoxLayout()
+        label = aqt.qt.QLabel(constants.GUI_TEXT_TARGET_INSERT_AUDIO_META)
+        label.setWordWrap(True)
+        vlayout.addWidget(label)
+        vlayout.addWidget(self.checkbox_insert_audio_meta)
+        groupbox.setLayout(vlayout)
+        self.batch_target_layout.addWidget(groupbox)
 
         self.batch_target_layout.addStretch()
 
@@ -115,6 +129,7 @@ class BatchTarget(component_common.ConfigComponentBase):
         self.radio_button_text_sound.toggled.connect(self.update_text_sound)
         self.radio_button_remove_sound.toggled.connect(self.update_remove_sound)
         self.radio_button_keep_sound.toggled.connect(self.update_remove_sound)
+        self.checkbox_insert_audio_meta.toggled.connect(self.update_insert_audio_meta)
 
     def update_text_sound(self):
         self.batch_target_model.text_and_sound_tag = self.radio_button_text_sound.isChecked()
@@ -122,6 +137,10 @@ class BatchTarget(component_common.ConfigComponentBase):
 
     def update_remove_sound(self):
         self.batch_target_model.remove_sound_tag = self.radio_button_remove_sound.isChecked()
+        self.notify_model_update()
+
+    def update_insert_audio_meta(self):
+        self.batch_target_model.insert_audio_meta = self.checkbox_insert_audio_meta.isChecked()
         self.notify_model_update()
 
     def update_field(self):

--- a/hypertts_addon/config_models.py
+++ b/hypertts_addon/config_models.py
@@ -137,6 +137,7 @@ class BatchTarget():
     remove_sound_tag: bool = True
     insert_location: InsertLocation = InsertLocation.AFTER
     same_field: bool = False
+    insert_audio_meta: bool = False
 
     def serialize(self):
         return serialize_batch_target(self)
@@ -147,9 +148,10 @@ class BatchTarget():
 
     def __str__(self):
         return f'{self.target_field}'
-        
+
     def __repr__(self):
-        return f"BatchTarget(target_field={self.target_field}, text_and_sound_tag={self.text_and_sound_tag}, remove_sound_tag={self.remove_sound_tag})"
+        return (f"BatchTarget(target_field={self.target_field}, text_and_sound_tag={self.text_and_sound_tag}, "
+                f"remove_sound_tag={self.remove_sound_tag}, insert_audio_meta={self.insert_audio_meta})")
 
 def serialize_batch_target(batch_target):
     return databind.json.dump(batch_target, BatchTarget)

--- a/hypertts_addon/constants.py
+++ b/hypertts_addon/constants.py
@@ -228,6 +228,7 @@ GUI_TEXT_TARGET_FIELD = """Sound tags will be inserted in this field"""
 GUI_TEXT_TARGET_TEXT_AND_SOUND = """<i>Should the target field only contain the sound tag, or should
 it contain both text and sound tag.</i>"""
 GUI_TEXT_TARGET_REMOVE_SOUND_TAG = """<i>If the target field already contains a sound tag, should it get  removed?</i>"""
+GUI_TEXT_TARGET_INSERT_AUDIO_META = """<i>Insert the selected voice as non-displaying, searchable text in the target field. The HTML editor can be used to show the text.</i>"""
 
 GUI_TEXT_BATCH_COMPLETED = """<b>Finished adding Audio to notes</b>. You can undo this operation in menu Edit, 
 Undo HyperTTS: Add Audio to Notes. You may close this dialog.

--- a/hypertts_addon/hypertts.py
+++ b/hypertts_addon/hypertts.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import re
+import html
 import hashlib
 import random
 import copy
@@ -121,7 +122,7 @@ class HyperTTS():
             source_text = self.get_source_text(note, batch.source, text_override)
             processed_text = self.process_text(source_text, batch.text_processing)
 
-        full_filename, audio_filename = self.get_audio_file(processed_text, batch.voice_selection, audio_request_context)
+        full_filename, audio_filename, voice_with_options = self.get_audio_file(processed_text, batch.voice_selection, audio_request_context)
         sound_tag, sound_file = self.get_collection_sound_tag(full_filename, audio_filename)
 
         target_field_content = note[target_field]
@@ -130,6 +131,9 @@ class HyperTTS():
         if batch.target.remove_sound_tag == True:
             target_field_content = text_utils.strip_sound_tag(target_field_content)
 
+        # always strip our own meta markers; we own this class and clean up on every regen
+        target_field_content = text_utils.strip_hypertts_meta(target_field_content)
+
         if batch.target.text_and_sound_tag == True:
             # user wants text and sound tag together, append the sound tag
             target_field_content = f'{target_field_content} {sound_tag}'
@@ -137,6 +141,9 @@ class HyperTTS():
             # user only wants sound tags
             target_field_content = self.keep_only_sound_tags(target_field_content)
             target_field_content = f'{target_field_content} {sound_tag}'
+
+        if batch.target.insert_audio_meta:
+            target_field_content = f'{target_field_content} {self.build_audio_meta_span(voice_with_options)}'
 
         target_field_content = target_field_content.strip()
 
@@ -152,7 +159,8 @@ class HyperTTS():
         source_text = self.get_source_text(note, batch.source, text_override)
         processed_text = text_utils.process_text(source_text, batch.text_processing)
         text_utils.check_length(processed_text)
-        return self.get_audio_file(processed_text, batch.voice_selection, audio_request_context)
+        full_filename, audio_filename, _voice = self.get_audio_file(processed_text, batch.voice_selection, audio_request_context)
+        return full_filename, audio_filename
 
     def get_realtime_audio(self, realtime_model: config_models.RealtimeConfigSide, text):
         if not realtime_model.side_enabled:
@@ -160,7 +168,8 @@ class HyperTTS():
         source_text = text
         processed_text = text_utils.process_text(source_text, realtime_model.text_processing)
         text_utils.check_length(processed_text)
-        return self.get_audio_file(processed_text, realtime_model.voice_selection, context.AudioRequestContext(constants.AudioRequestReason.realtime))
+        full_filename, audio_filename, _voice = self.get_audio_file(processed_text, realtime_model.voice_selection, context.AudioRequestContext(constants.AudioRequestReason.realtime))
+        return full_filename, audio_filename
 
     def get_audio_file(self, processed_text, voice_selection, audio_request_context):
         # sanity checks
@@ -184,11 +193,11 @@ class HyperTTS():
                 assert isinstance(voice_id, voice_module.TtsVoiceId_v3), \
                     f"Expected voice_id to be TtsVoiceId_v3, got {type(voice_id).__name__}, voice_with_options: {type(voice_with_options).__name__}"
 
-                full_filename, audio_filename = self.generate_audio_write_file(processed_text, 
+                full_filename, audio_filename = self.generate_audio_write_file(processed_text,
                     voice_with_options.voice_id, voice_with_options.options, audio_request_context)
                 logger.debug(f'finished generating audio file and write to file for {processed_text}')
                 self.config_register_added_audio()
-                return full_filename, audio_filename
+                return full_filename, audio_filename, voice_with_options
             except errors.AudioNotFoundError as exc:
                 # try the next voice, as long as one is available
                 if not priority_mode:
@@ -489,6 +498,11 @@ class HyperTTS():
         with _start_span(op="db.anki.media.add", name="media_add_file"):
             self.anki_utils.media_add_file(full_filename)
         return f'[sound:{audio_filename}]', audio_filename
+
+    def build_audio_meta_span(self, voice_with_options: config_models.VoiceWithOptions) -> str:
+        voice = self.service_manager.locate_voice(voice_with_options.voice_id)
+        escaped = html.escape(str(voice), quote=False)
+        return f'<span class="hypertts-meta" style="display:none">{escaped}</span>'
 
     def get_full_audio_file_name(self, hash_str, format: options.AudioFormat):
         # return the absolute path of the audio file in the user_files directory

--- a/hypertts_addon/text_utils.py
+++ b/hypertts_addon/text_utils.py
@@ -124,3 +124,7 @@ def check_length(text):
 def strip_sound_tag(field_value):
     field_value = re.sub(r'\[sound:[^\]]+\]', '', field_value)
     return field_value.strip()
+
+def strip_hypertts_meta(field_value):
+    field_value = re.sub(r'<span class="hypertts-meta"[^>]*>.*?</span>', '', field_value, flags=re.DOTALL)
+    return field_value.strip()

--- a/tests/test_audio_batch.py
+++ b/tests/test_audio_batch.py
@@ -851,3 +851,90 @@ def test_priority_voices_not_found(qtbot):
 
     # make sure we got a AudioNotFoundError in the batch error manager
     assert str(batch_status_obj[0].error) == 'Service request error for [老人家]: Audio not found in any voices (voice: None)'
+
+
+# insert_audio_meta tests
+# =======================
+
+def run_simple_batch_meta(insert_audio_meta, text_and_sound_tag=True, prepopulate_field=None, note_id=None):
+    config_gen = testing_utils.TestConfigGenerator()
+    hypertts_instance = config_gen.build_hypertts_instance_test_servicemanager('default')
+
+    voice_a_1 = get_default_voice_id(hypertts_instance)
+    single = config_models.VoiceSelectionSingle()
+    single.set_voice(config_models.VoiceWithOptions(voice_a_1, {}))
+
+    batch = config_models.BatchConfig(hypertts_instance.anki_utils)
+    source = config_models.BatchSource(mode=constants.BatchMode.simple, source_field='Chinese')
+    target = config_models.BatchTarget(
+        target_field='Sound',
+        text_and_sound_tag=text_and_sound_tag,
+        remove_sound_tag=True,
+        insert_audio_meta=insert_audio_meta,
+    )
+
+    batch.set_source(source)
+    batch.set_target(target)
+    batch.set_voice_selection(single)
+    batch.set_text_processing(config_models.TextProcessing())
+
+    note_id = note_id or config_gen.note_id_1
+    if prepopulate_field is not None:
+        note = hypertts_instance.anki_utils.get_note_by_id(note_id)
+        # field_dict is the mock's underlying storage; __setitem__ writes to set_values, not field_dict
+        note.field_dict['Sound'] = prepopulate_field
+
+    listener = MockBatchStatusListener(hypertts_instance.anki_utils)
+    batch_status_obj = batch_status.BatchStatus(hypertts_instance.anki_utils, [note_id], listener)
+    hypertts_instance.process_batch_audio([note_id], batch, batch_status_obj, testing_utils.MockCollection())
+
+    note = hypertts_instance.anki_utils.get_note_by_id(note_id)
+    return note.set_values['Sound']
+
+
+def test_insert_audio_meta_disabled_by_default(qtbot):
+    sound_field = run_simple_batch_meta(insert_audio_meta=False)
+    assert 'hypertts-meta' not in sound_field
+    assert '[sound:' in sound_field
+
+
+def test_insert_audio_meta_enabled_appends_span(qtbot):
+    sound_field = run_simple_batch_meta(insert_audio_meta=True)
+    # voice_a_1 is built as: name='voice_a_1', gender=Male, language=fr_FR ('French (France)'), service='ServiceA'
+    expected_inner = 'French (France), Male, voice_a_1 (ServiceA)'
+    assert '[sound:' in sound_field
+    assert f'<span class="hypertts-meta" style="display:none">{expected_inner}</span>' in sound_field
+    # span must appear after the sound tag
+    assert sound_field.index('[sound:') < sound_field.index('<span class="hypertts-meta"')
+
+
+def test_insert_audio_meta_strips_stale_meta_on_regen(qtbot):
+    stale = '<span class="hypertts-meta" style="display:none">OLD: stale voice</span>'
+    sound_field = run_simple_batch_meta(
+        insert_audio_meta=True,
+        prepopulate_field=f'pre-existing text {stale}',
+    )
+    assert 'OLD: stale voice' not in sound_field
+    # exactly one meta span remains
+    assert sound_field.count('class="hypertts-meta"') == 1
+
+
+def test_insert_audio_meta_disabled_still_strips_stale_meta(qtbot):
+    # we own the hypertts-meta class, so regeneration cleans it up even when
+    # the user has the meta feature turned off
+    stale = '<span class="hypertts-meta" style="display:none">OLD: stale voice</span>'
+    sound_field = run_simple_batch_meta(
+        insert_audio_meta=False,
+        prepopulate_field=f'pre-existing text {stale}',
+    )
+    assert 'hypertts-meta' not in sound_field
+    assert 'OLD: stale voice' not in sound_field
+
+
+def test_insert_audio_meta_sound_only_mode_appends_span(qtbot):
+    # exercises the else branch of process_note_audio (sound-only, no text)
+    sound_field = run_simple_batch_meta(insert_audio_meta=True, text_and_sound_tag=False)
+    expected_inner = 'French (France), Male, voice_a_1 (ServiceA)'
+    assert '[sound:' in sound_field
+    assert f'<span class="hypertts-meta" style="display:none">{expected_inner}</span>' in sound_field
+    assert sound_field.index('[sound:') < sound_field.index('<span class="hypertts-meta"')

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -385,7 +385,8 @@ class ConfigModelsTests(unittest.TestCase):
                 'text_and_sound_tag': False,
                 'remove_sound_tag': False,
                 'insert_location': 'AFTER',
-                'same_field': False
+                'same_field': False,
+                'insert_audio_meta': False
             },
             'voice_selection': {
                 'voice_selection_mode': 'single',
@@ -452,7 +453,8 @@ class ConfigModelsTests(unittest.TestCase):
                     'text_and_sound_tag': text_and_sound_tag,
                     'remove_sound_tag': remove_sound_tag,
                     'insert_location': 'AFTER',
-                    'same_field': False
+                    'same_field': False,
+                    'insert_audio_meta': False
                 }
                 assert batch_config.serialize()['target'] == expected_output
 
@@ -473,6 +475,7 @@ class ConfigModelsTests(unittest.TestCase):
         self.assertEqual(batch_target.remove_sound_tag, True)
         self.assertEqual(batch_target.insert_location, config_models.InsertLocation.AFTER)
         self.assertEqual(batch_target.same_field, False)
+        self.assertEqual(batch_target.insert_audio_meta, False)
 
 
     def test_batch_config_target_deserialize_schema_v4(self):
@@ -490,6 +493,7 @@ class ConfigModelsTests(unittest.TestCase):
         self.assertEqual(batch_target.remove_sound_tag, True)
         self.assertEqual(batch_target.insert_location, config_models.InsertLocation.CURSOR_LOCATION)
         self.assertEqual(batch_target.same_field, True)
+        self.assertEqual(batch_target.insert_audio_meta, False)
 
 
     def test_text_processing(self):
@@ -764,7 +768,8 @@ class ConfigModelsTests(unittest.TestCase):
                 'text_and_sound_tag': False,
                 'remove_sound_tag': False,
                 'insert_location': 'AFTER',
-                'same_field': False
+                'same_field': False,
+                'insert_audio_meta': False
             },
             'voice_selection': {
                 'voice_selection_mode': 'single',

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -262,6 +262,28 @@ def test_strip_sound_tag_function(qtbot):
     assert text_utils.strip_sound_tag('[not a sound tag]') == '[not a sound tag]'
     assert text_utils.strip_sound_tag('[sound:] empty') == '[sound:] empty'  # Empty sound tag (malformed)
 
+def test_strip_hypertts_meta(qtbot):
+    """Test the strip_hypertts_meta function directly"""
+    span = '<span class="hypertts-meta" style="display:none">English (US), Female, Rachel (ElevenLabs)</span>'
+    assert text_utils.strip_hypertts_meta(span) == ''
+    assert text_utils.strip_hypertts_meta(f'[sound:a.mp3] {span}') == '[sound:a.mp3]'
+    assert text_utils.strip_hypertts_meta(f'{span} text') == 'text'
+
+    # multiple spans
+    assert text_utils.strip_hypertts_meta(f'{span}{span}') == ''
+
+    # content containing newlines is still stripped (regex uses re.DOTALL)
+    multiline_span = '<span class="hypertts-meta" style="display:none">first line\nsecond line</span>'
+    assert text_utils.strip_hypertts_meta(multiline_span) == ''
+
+    # does not strip other spans
+    other_span = '<span class="foo">bar</span>'
+    assert text_utils.strip_hypertts_meta(other_span) == other_span
+
+    # empty / no meta
+    assert text_utils.strip_hypertts_meta('') == ''
+    assert text_utils.strip_hypertts_meta('Hello world') == 'Hello world'
+
 def test_check_length(qtbot):
     # valid text should not raise
     text_utils.check_length('hello')


### PR DESCRIPTION
## Summary

Adds an opt-in `BatchTarget.insert_audio_meta` setting. When enabled,
audio generation appends a hidden span next to the `[sound:...]` tag
recording which voice/service produced the clip, so notes become
searchable by voice in the Anki browser:

    [sound:hypertts-….mp3] <span class="hypertts-meta" style="display:none">{voice}</span>

The voice string matches the voice-selection dropdown. Off by default.

## Behavior notes (for review)

- **Strip is unconditional.** `text_utils.strip_hypertts_meta` runs on
  every regeneration regardless of the flag — the `hypertts-meta` class
  is addon-owned, so we clean up our own markers. This means disabling
  the feature and regenerating removes stale spans rather than leaving
  them orphaned.
- **Easy mode** intentionally has no checkbox (simplified UI), so the
  feature can't be enabled there — but its Add Audio path shares
  `process_note_audio`, so the strip still cleans existing spans on
  regen. (Confirmed desired.)
- **Preview is unaffected** — it's read-only and never writes the field.

## UI

New "Insert audio info" checkbox in the target panel with a one-line
italic helper. Label lives in `constants.GUI_TEXT_TARGET_INSERT_AUDIO_META`.

<img width="1339" height="979" alt="target-dialog" src="https://github.com/user-attachments/assets/24afc4c4-9c7f-4c32-9835-2df462510079" />

## Upgrade compatibility

Existing presets written before this change have no `insert_audio_meta`
key; they deserialize with the field defaulting to `False`. Covered by
`test_batch_config_target_deserialize_schema_v3/v4`.

## Testing

- `QT_QPA_PLATFORM=offscreen pytest -n auto --ignore=tests/test_tts_services`
  → 307 passed, 2 skipped. (The one `test_trial_request_payload` failure
  is a pre-existing env-specific machine-UUID mismatch, unrelated to this PR.)
- Manual: browser search, hidden-in-review / visible-in-HTML-editor,
  disable-then-regen strip, no duplication, all three write paths,
  non-ASCII voice names, sound-only vs text+sound, content preservation,
  setting persistence, cross-mode strip via Easy mode.
