### PR TITLE
Increase Azure MP3 output bitrate to 192 kbps

### DIFF
--- a/hypertts_addon/services/service_azure.py
+++ b/hypertts_addon/services/service_azure.py
@@ -120,7 +120,7 @@ class Azure(service.ServiceBase):
         audio_format_str = voice_options.get(options.AUDIO_FORMAT_PARAMETER, options.AudioFormat.mp3.name)
         audio_format = options.AudioFormat[audio_format_str]
         audio_format_map = {
-            options.AudioFormat.mp3: 'audio-24khz-96kbitrate-mono-mp3',
+            options.AudioFormat.mp3: 'audio-48khz-192kbitrate-mono-mp3',
             options.AudioFormat.ogg_opus: 'ogg-48khz-16bit-mono-opus'
         }
 


### PR DESCRIPTION
It's a significant improvement in audio quality with no Azure billing change. The comparison is pretty clear.
[azure_new_48khz_192kbps.mp3](https://github.com/user-attachments/files/29899955/azure_new_48khz_192kbps.mp3)
[azure_old_24khz_96kbps.mp3](https://github.com/user-attachments/files/29899957/azure_old_24khz_96kbps.mp3)
