### PR TITLE
ElevenLabs: request 192 kbps mp3 with graceful 128 kbps tier fallback

### DIFF
--- a/hypertts_addon/services/service_elevenlabs.py
+++ b/hypertts_addon/services/service_elevenlabs.py
@@ -13,8 +13,17 @@ logger = logging_utils.get_child_logger(__name__)
 class ElevenLabs(service.ServiceBase):
     CONFIG_API_KEY = 'api_key'
 
+    # 192 kbps mp3 requires an ElevenLabs Creator tier (or above); 128 kbps is
+    # available on every tier including Free. We request the higher bitrate and
+    # transparently fall back to 128 kbps for accounts whose tier rejects it.
+    MP3_OUTPUT_FORMAT_HQ = 'mp3_44100_192'
+    MP3_OUTPUT_FORMAT_DEFAULT = 'mp3_44100_128'
+
     def __init__(self):
         service.ServiceBase.__init__(self)
+        # flips to True once we observe this account cannot produce 192 kbps
+        # mp3, so we stop probing the higher bitrate on every request
+        self._mp3_hq_unsupported = False
 
     def cloudlanguagetools_enabled(self):
         return True
@@ -35,6 +44,9 @@ class ElevenLabs(service.ServiceBase):
     def configure(self, config):
         self._config = config
         self.api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
+        # re-probe the high-bitrate capability after a (re)configuration, e.g.
+        # when the user switches key or upgrades their subscription tier
+        self._mp3_hq_unsupported = False
 
     def voice_list(self):
         return self.basic_voice_list()
@@ -43,12 +55,10 @@ class ElevenLabs(service.ServiceBase):
         api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
 
         voice_id = voice.voice_key['voice_id']
-        url = f'https://api.elevenlabs.io/v1/text-to-speech/{voice_id}'
+        base_url = f'https://api.elevenlabs.io/v1/text-to-speech/{voice_id}'
 
         # Handle audio format
         audio_format_str = voice_options.get(options.AUDIO_FORMAT_PARAMETER, voice.options.get(options.AUDIO_FORMAT_PARAMETER, {}).get('default', 'mp3'))
-        if audio_format_str == 'ogg_opus':
-            url += '?output_format=opus_48000_192'
 
         headers = {
             "Accept": "audio/mpeg",
@@ -74,12 +84,46 @@ class ElevenLabs(service.ServiceBase):
         if language_code:
             data['language_code'] = language_code
 
-        response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
-        if response.status_code != 200:
-            error_message = f'{self.name}: error processing TTS request: {response.status_code} {response.text}'
-            logger.warning(error_message)
-            if response.status_code in (401, 402):
-                raise errors.ServicePermissionError(source_text, voice, error_message)
-            raise errors.RequestError(source_text, voice, error_message)
+        if audio_format_str == 'ogg_opus':
+            return self._request_audio(f'{base_url}?output_format=opus_48000_192', data, headers, source_text, voice)
 
-        return response.content
+        return self._request_mp3_audio(base_url, data, headers, source_text, voice)
+
+    def _request_mp3_audio(self, base_url, data, headers, source_text, voice):
+        # Request 192 kbps first, then fall back to the universally-available
+        # 128 kbps when the account tier rejects the higher bitrate. We don't
+        # know the exact status code ElevenLabs uses to signal that, so we only
+        # treat it as tier-limited when the 128 kbps retry actually succeeds --
+        # a genuine error (bad key, quota, unsupported voice) fails at both
+        # bitrates and is surfaced unchanged.
+        if not self._mp3_hq_unsupported:
+            url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_HQ}'
+            response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
+            if response.status_code == 200:
+                return response.content
+            # 5xx / timeout is transient and 429 is a rate limit; neither is
+            # fixed by a lower bitrate, so surface those directly.
+            if not (400 <= response.status_code < 500 and response.status_code != 429):
+                self._raise_for_response(response, source_text, voice)
+            logger.info(f'{self.name}: 192kbps mp3 request returned {response.status_code}; retrying at 128kbps')
+
+        url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_DEFAULT}'
+        response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
+        if response.status_code == 200:
+            # 128 kbps worked (possibly where 192 kbps did not): tier-limited
+            self._mp3_hq_unsupported = True
+            return response.content
+        self._raise_for_response(response, source_text, voice)
+
+    def _request_audio(self, url, data, headers, source_text, voice):
+        response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
+        if response.status_code == 200:
+            return response.content
+        self._raise_for_response(response, source_text, voice)
+
+    def _raise_for_response(self, response, source_text, voice):
+        error_message = f'{self.name}: error processing TTS request: {response.status_code} {response.text}'
+        logger.warning(error_message)
+        if response.status_code in (401, 402):
+            raise errors.ServicePermissionError(source_text, voice, error_message)
+        raise errors.RequestError(source_text, voice, error_message)

--- a/hypertts_addon/services/service_elevenlabs.py
+++ b/hypertts_addon/services/service_elevenlabs.py
@@ -91,21 +91,23 @@ class ElevenLabs(service.ServiceBase):
 
     def _request_mp3_audio(self, base_url, data, headers, source_text, voice):
         # Request 192 kbps first, then fall back to the universally-available
-        # 128 kbps when the account tier rejects the higher bitrate. We don't
-        # know the exact status code ElevenLabs uses to signal that, so we only
-        # treat it as tier-limited when the 128 kbps retry actually succeeds --
-        # a genuine error (bad key, quota, unsupported voice) fails at both
-        # bitrates and is surfaced unchanged.
+        # 128 kbps when the account tier rejects the higher bitrate. As a
+        # safety net we only treat it as tier-limited when the 128 kbps retry
+        # actually succeeds -- a genuine error is surfaced unchanged.
         if not self._mp3_hq_unsupported:
             url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_HQ}'
             response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
             if response.status_code == 200:
                 return response.content
-            # 5xx / timeout is transient and 429 is a rate limit; neither is
-            # fixed by a lower bitrate, so surface those directly.
-            if not (400 <= response.status_code < 500 and response.status_code != 429):
+            # A tier that cannot use 192 kbps is rejected with HTTP 403, e.g.
+            # {"detail":{"code":"subscription_required","status":"output_format_not_allowed",
+            #  "message":"Output format 'mp3_44100_192' is only available on the
+            #  Creator tier and above."}}. Every other error (401 quota/auth,
+            # 402 paid plan, 400 input, 429 rate limit, 5xx transient) is not
+            # fixed by a lower bitrate, so surface it directly.
+            if response.status_code != 403:
                 self._raise_for_response(response, source_text, voice)
-            logger.info(f'{self.name}: 192kbps mp3 request returned {response.status_code}; retrying at 128kbps')
+            logger.info(f'{self.name}: 192kbps mp3 not allowed on this tier; retrying at 128kbps')
 
         url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_DEFAULT}'
         response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)

--- a/hypertts_addon/services/service_elevenlabscustom.py
+++ b/hypertts_addon/services/service_elevenlabscustom.py
@@ -245,21 +245,23 @@ class ElevenLabsCustom(service.ServiceBase):
 
     def _request_mp3_audio(self, base_url, data, headers, source_text, voice):
         # Request 192 kbps first, then fall back to the universally-available
-        # 128 kbps when the account tier rejects the higher bitrate. We don't
-        # know the exact status code ElevenLabs uses to signal that, so we only
-        # treat it as tier-limited when the 128 kbps retry actually succeeds --
-        # a genuine error (bad key, quota, unsupported voice) fails at both
-        # bitrates and is surfaced unchanged.
+        # 128 kbps when the account tier rejects the higher bitrate. As a
+        # safety net we only treat it as tier-limited when the 128 kbps retry
+        # actually succeeds -- a genuine error is surfaced unchanged.
         if not self._mp3_hq_unsupported:
             url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_HQ}'
             response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
             if response.status_code == 200:
                 return response.content
-            # 5xx / timeout is transient and 429 is a rate limit; neither is
-            # fixed by a lower bitrate, so surface those directly.
-            if not (400 <= response.status_code < 500 and response.status_code != 429):
+            # A tier that cannot use 192 kbps is rejected with HTTP 403, e.g.
+            # {"detail":{"code":"subscription_required","status":"output_format_not_allowed",
+            #  "message":"Output format 'mp3_44100_192' is only available on the
+            #  Creator tier and above."}}. Every other error (401 quota/auth,
+            # 402 paid plan, 400 input, 429 rate limit, 5xx transient) is not
+            # fixed by a lower bitrate, so surface it directly.
+            if response.status_code != 403:
                 self._raise_for_response(response, source_text, voice)
-            logger.info(f'{self.name}: 192kbps mp3 request returned {response.status_code}; retrying at 128kbps')
+            logger.info(f'{self.name}: 192kbps mp3 not allowed on this tier; retrying at 128kbps')
 
         url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_DEFAULT}'
         response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)

--- a/hypertts_addon/services/service_elevenlabscustom.py
+++ b/hypertts_addon/services/service_elevenlabscustom.py
@@ -70,8 +70,17 @@ GENDER_MAP = {
 class ElevenLabsCustom(service.ServiceBase):
     CONFIG_API_KEY = 'api_key'
 
+    # 192 kbps mp3 requires an ElevenLabs Creator tier (or above); 128 kbps is
+    # available on every tier including Free. We request the higher bitrate and
+    # transparently fall back to 128 kbps for accounts whose tier rejects it.
+    MP3_OUTPUT_FORMAT_HQ = 'mp3_44100_192'
+    MP3_OUTPUT_FORMAT_DEFAULT = 'mp3_44100_128'
+
     def __init__(self):
         service.ServiceBase.__init__(self)
+        # flips to True once we observe this account cannot produce 192 kbps
+        # mp3, so we stop probing the higher bitrate on every request
+        self._mp3_hq_unsupported = False
 
     def cloudlanguagetools_enabled(self):
         return False
@@ -92,6 +101,9 @@ class ElevenLabsCustom(service.ServiceBase):
     def configure(self, config):
         self._config = config
         self.api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
+        # re-probe the high-bitrate capability after a (re)configuration, e.g.
+        # when the user switches key or upgrades their subscription tier
+        self._mp3_hq_unsupported = False
 
     def get_headers(self):
         api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
@@ -199,12 +211,10 @@ class ElevenLabsCustom(service.ServiceBase):
     def get_tts_audio(self, source_text, voice: voice.TtsVoice_v3, voice_options):
 
         voice_id = voice.voice_key['voice_id']
-        url = f'https://api.elevenlabs.io/v1/text-to-speech/{voice_id}'
+        base_url = f'https://api.elevenlabs.io/v1/text-to-speech/{voice_id}'
 
         # Handle audio format
         audio_format_str = voice_options.get(options.AUDIO_FORMAT_PARAMETER, voice.options.get(options.AUDIO_FORMAT_PARAMETER, {}).get('default', 'mp3'))
-        if audio_format_str == 'ogg_opus':
-            url += '?output_format=opus_48000_192'
 
         headers = self.get_headers()
         headers['Accept'] = "audio/mpeg"
@@ -228,18 +238,52 @@ class ElevenLabsCustom(service.ServiceBase):
         if language_code:
             data['language_code'] = language_code
 
-        response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
-        if response.status_code != 200:
-            error_message = f'{self.name}: error processing TTS request: {response.status_code} {response.text}'
-            logger.warning(error_message)
-            if response.status_code in (401, 402):
-                raise errors.ServicePermissionError(source_text, voice, error_message)
-            if response.status_code == 400:
-                # ElevenLabs returns 400 for permanent input-validation failures
-                # like unsupported language_code, voice_id not found, model_id
-                # not compatible with language, etc. These should not be retried.
-                # Sentry ANKI-HYPER-TTS-HGT.
-                raise errors.ServiceInputError(source_text, voice, error_message)
-            raise errors.RequestError(source_text, voice, error_message)
+        if audio_format_str == 'ogg_opus':
+            return self._request_audio(f'{base_url}?output_format=opus_48000_192', data, headers, source_text, voice)
 
-        return response.content
+        return self._request_mp3_audio(base_url, data, headers, source_text, voice)
+
+    def _request_mp3_audio(self, base_url, data, headers, source_text, voice):
+        # Request 192 kbps first, then fall back to the universally-available
+        # 128 kbps when the account tier rejects the higher bitrate. We don't
+        # know the exact status code ElevenLabs uses to signal that, so we only
+        # treat it as tier-limited when the 128 kbps retry actually succeeds --
+        # a genuine error (bad key, quota, unsupported voice) fails at both
+        # bitrates and is surfaced unchanged.
+        if not self._mp3_hq_unsupported:
+            url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_HQ}'
+            response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
+            if response.status_code == 200:
+                return response.content
+            # 5xx / timeout is transient and 429 is a rate limit; neither is
+            # fixed by a lower bitrate, so surface those directly.
+            if not (400 <= response.status_code < 500 and response.status_code != 429):
+                self._raise_for_response(response, source_text, voice)
+            logger.info(f'{self.name}: 192kbps mp3 request returned {response.status_code}; retrying at 128kbps')
+
+        url = f'{base_url}?output_format={self.MP3_OUTPUT_FORMAT_DEFAULT}'
+        response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
+        if response.status_code == 200:
+            # 128 kbps worked (possibly where 192 kbps did not): tier-limited
+            self._mp3_hq_unsupported = True
+            return response.content
+        self._raise_for_response(response, source_text, voice)
+
+    def _request_audio(self, url, data, headers, source_text, voice):
+        response = requests.post(url, json=data, headers=headers, timeout=constants.RequestTimeout)
+        if response.status_code == 200:
+            return response.content
+        self._raise_for_response(response, source_text, voice)
+
+    def _raise_for_response(self, response, source_text, voice):
+        error_message = f'{self.name}: error processing TTS request: {response.status_code} {response.text}'
+        logger.warning(error_message)
+        if response.status_code in (401, 402):
+            raise errors.ServicePermissionError(source_text, voice, error_message)
+        if response.status_code == 400:
+            # ElevenLabs returns 400 for permanent input-validation failures
+            # like unsupported language_code, voice_id not found, model_id
+            # not compatible with language, etc. These should not be retried.
+            # Sentry ANKI-HYPER-TTS-HGT.
+            raise errors.ServiceInputError(source_text, voice, error_message)
+        raise errors.RequestError(source_text, voice, error_message)

--- a/tests/test_tts_services/test_elevenlabs.py
+++ b/tests/test_tts_services/test_elevenlabs.py
@@ -343,5 +343,191 @@ class TestElevenLabsQuotaError(unittest.TestCase):
                 service.get_tts_audio('Hello', mock_voice, {})
 
 
+class TestElevenLabsBitrate(unittest.TestCase):
+    """Mock tests for the 192 kbps mp3 request + 128 kbps tier fallback."""
+
+    def _make_mock_voice(self, service_name):
+        from hypertts_addon import voice as voice_module
+        return voice_module.TtsVoice_v3(
+            name='Test Voice',
+            voice_key={'voice_id': 'test_id', 'model_id': 'eleven_monolingual_v1'},
+            options={
+                'stability': {'type': 'number', 'min': 0.0, 'max': 1.0, 'default': 0.5},
+                'similarity_boost': {'type': 'number', 'min': 0.0, 'max': 1.0, 'default': 0.75},
+            },
+            service=service_name,
+            gender=constants.Gender.Male,
+            audio_languages=[AudioLanguage.en_US],
+            service_fee=constants.ServiceFee.paid,
+        )
+
+    def _resp(self, status_code, content=b'audio-bytes', text=''):
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = status_code
+        r.content = content
+        r.text = text
+        return r
+
+    def _urls(self, mock_post):
+        # url is the first positional arg to requests.post(url, json=..., ...)
+        return [call.args[0] for call in mock_post.call_args_list]
+
+    # --- ElevenLabs (managed) ---------------------------------------------
+
+    def test_mp3_requests_192kbps_first(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_requests_192kbps_first'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabs import ElevenLabs
+
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabs')
+
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post',
+                   return_value=self._resp(200, content=b'hq')) as mock_post:
+            result = service.get_tts_audio('Hello', voice, {})
+
+        self.assertEqual(result, b'hq')
+        urls = self._urls(mock_post)
+        self.assertEqual(len(urls), 1)
+        self.assertIn('output_format=mp3_44100_192', urls[0])
+        self.assertFalse(service._mp3_hq_unsupported)
+
+    def test_mp3_falls_back_to_128kbps_on_tier_rejection(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_falls_back_to_128kbps_on_tier_rejection'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabs import ElevenLabs
+
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabs')
+
+        responses = [self._resp(401, text='tier too low'), self._resp(200, content=b'sd')]
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post',
+                   side_effect=responses) as mock_post:
+            result = service.get_tts_audio('Hello', voice, {})
+
+        self.assertEqual(result, b'sd')
+        urls = self._urls(mock_post)
+        self.assertEqual(len(urls), 2)
+        self.assertIn('output_format=mp3_44100_192', urls[0])
+        self.assertIn('output_format=mp3_44100_128', urls[1])
+        # tier limitation should be remembered
+        self.assertTrue(service._mp3_hq_unsupported)
+
+    def test_mp3_skips_192kbps_after_tier_rejection_cached(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_skips_192kbps_after_tier_rejection_cached'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabs import ElevenLabs
+
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        service._mp3_hq_unsupported = True
+        voice = self._make_mock_voice('ElevenLabs')
+
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post',
+                   return_value=self._resp(200, content=b'sd')) as mock_post:
+            result = service.get_tts_audio('Hello', voice, {})
+
+        self.assertEqual(result, b'sd')
+        urls = self._urls(mock_post)
+        self.assertEqual(len(urls), 1)
+        self.assertIn('output_format=mp3_44100_128', urls[0])
+
+    def test_mp3_genuine_error_fails_at_both_bitrates(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_genuine_error_fails_at_both_bitrates'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabs import ElevenLabs
+
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabs')
+
+        # 401 at both bitrates (e.g. quota_exceeded) -> surfaced, not silently downgraded
+        responses = [self._resp(401, text='quota_exceeded'), self._resp(401, text='quota_exceeded')]
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post',
+                   side_effect=responses):
+            with self.assertRaises(errors.ServicePermissionError):
+                service.get_tts_audio('Hello', voice, {})
+        # must NOT be remembered as tier-limited when 128 kbps also failed
+        self.assertFalse(service._mp3_hq_unsupported)
+
+    def test_mp3_5xx_not_downgraded(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_5xx_not_downgraded'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabs import ElevenLabs
+
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabs')
+
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post',
+                   return_value=self._resp(500, text='server error')) as mock_post:
+            with self.assertRaises(errors.RequestError):
+                service.get_tts_audio('Hello', voice, {})
+        # transient error must not trigger a 128 kbps retry
+        self.assertEqual(len(self._urls(mock_post)), 1)
+
+    def test_ogg_still_uses_opus_192(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_ogg_still_uses_opus_192'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabs import ElevenLabs
+
+        service = ElevenLabs()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabs')
+
+        with patch('hypertts_addon.services.service_elevenlabs.requests.post',
+                   return_value=self._resp(200, content=b'ogg')) as mock_post:
+            result = service.get_tts_audio('Hello', voice, {'format': 'ogg_opus'})
+
+        self.assertEqual(result, b'ogg')
+        urls = self._urls(mock_post)
+        self.assertEqual(len(urls), 1)
+        self.assertIn('output_format=opus_48000_192', urls[0])
+
+    # --- ElevenLabsCustom -------------------------------------------------
+
+    def test_custom_mp3_falls_back_to_128kbps(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_custom_mp3_falls_back_to_128kbps'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabscustom import ElevenLabsCustom
+
+        service = ElevenLabsCustom()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabsCustom')
+
+        responses = [self._resp(401, text='tier too low'), self._resp(200, content=b'sd')]
+        with patch('hypertts_addon.services.service_elevenlabscustom.requests.post',
+                   side_effect=responses) as mock_post:
+            result = service.get_tts_audio('Hello', voice, {})
+
+        self.assertEqual(result, b'sd')
+        urls = self._urls(mock_post)
+        self.assertEqual(len(urls), 2)
+        self.assertIn('output_format=mp3_44100_192', urls[0])
+        self.assertIn('output_format=mp3_44100_128', urls[1])
+        self.assertTrue(service._mp3_hq_unsupported)
+
+    def test_custom_mp3_400_input_error_preserved(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_custom_mp3_400_input_error_preserved'
+        from unittest.mock import patch
+        from hypertts_addon.services.service_elevenlabscustom import ElevenLabsCustom
+
+        service = ElevenLabsCustom()
+        service.configure({'api_key': 'fake_key'})
+        voice = self._make_mock_voice('ElevenLabsCustom')
+
+        # 400 at both bitrates (e.g. unsupported language_code) -> ServiceInputError,
+        # and the account must not be remembered as tier-limited
+        responses = [self._resp(400, text='bad language_code'), self._resp(400, text='bad language_code')]
+        with patch('hypertts_addon.services.service_elevenlabscustom.requests.post',
+                   side_effect=responses):
+            with self.assertRaises(errors.ServiceInputError):
+                service.get_tts_audio('Hello', voice, {})
+        self.assertFalse(service._mp3_hq_unsupported)
+
+
 class TestElevenLabsCLT(TestElevenLabs):
     CONFIG_MODE = 'clt'

--- a/tests/test_tts_services/test_elevenlabs.py
+++ b/tests/test_tts_services/test_elevenlabs.py
@@ -403,7 +403,11 @@ class TestElevenLabsBitrate(unittest.TestCase):
         service.configure({'api_key': 'fake_key'})
         voice = self._make_mock_voice('ElevenLabs')
 
-        responses = [self._resp(401, text='tier too low'), self._resp(200, content=b'sd')]
+        # real ElevenLabs rejection for a too-high bitrate: HTTP 403
+        rejection = self._resp(403, text='{"detail":{"code":"subscription_required",'
+                               '"status":"output_format_not_allowed","message":"Output format '
+                               "'mp3_44100_192' is only available on the Creator tier and above.\"}}")
+        responses = [rejection, self._resp(200, content=b'sd')]
         with patch('hypertts_addon.services.service_elevenlabs.requests.post',
                    side_effect=responses) as mock_post:
             result = service.get_tts_audio('Hello', voice, {})
@@ -435,8 +439,8 @@ class TestElevenLabsBitrate(unittest.TestCase):
         self.assertEqual(len(urls), 1)
         self.assertIn('output_format=mp3_44100_128', urls[0])
 
-    def test_mp3_genuine_error_fails_at_both_bitrates(self):
-        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_genuine_error_fails_at_both_bitrates'
+    def test_mp3_non_tier_error_surfaced_without_retry(self):
+        # pytest tests/test_tts_services/test_elevenlabs.py -k 'test_mp3_non_tier_error_surfaced_without_retry'
         from unittest.mock import patch
         from hypertts_addon.services.service_elevenlabs import ElevenLabs
 
@@ -444,13 +448,13 @@ class TestElevenLabsBitrate(unittest.TestCase):
         service.configure({'api_key': 'fake_key'})
         voice = self._make_mock_voice('ElevenLabs')
 
-        # 401 at both bitrates (e.g. quota_exceeded) -> surfaced, not silently downgraded
-        responses = [self._resp(401, text='quota_exceeded'), self._resp(401, text='quota_exceeded')]
+        # 401 quota_exceeded is not a tier/format problem: surface it immediately,
+        # do not probe 128 kbps, and do not remember the account as tier-limited
         with patch('hypertts_addon.services.service_elevenlabs.requests.post',
-                   side_effect=responses):
+                   return_value=self._resp(401, text='quota_exceeded')) as mock_post:
             with self.assertRaises(errors.ServicePermissionError):
                 service.get_tts_audio('Hello', voice, {})
-        # must NOT be remembered as tier-limited when 128 kbps also failed
+        self.assertEqual(len(self._urls(mock_post)), 1)
         self.assertFalse(service._mp3_hq_unsupported)
 
     def test_mp3_5xx_not_downgraded(self):
@@ -498,7 +502,8 @@ class TestElevenLabsBitrate(unittest.TestCase):
         service.configure({'api_key': 'fake_key'})
         voice = self._make_mock_voice('ElevenLabsCustom')
 
-        responses = [self._resp(401, text='tier too low'), self._resp(200, content=b'sd')]
+        rejection = self._resp(403, text='{"detail":{"status":"output_format_not_allowed"}}')
+        responses = [rejection, self._resp(200, content=b'sd')]
         with patch('hypertts_addon.services.service_elevenlabscustom.requests.post',
                    side_effect=responses) as mock_post:
             result = service.get_tts_audio('Hello', voice, {})
@@ -519,13 +524,13 @@ class TestElevenLabsBitrate(unittest.TestCase):
         service.configure({'api_key': 'fake_key'})
         voice = self._make_mock_voice('ElevenLabsCustom')
 
-        # 400 at both bitrates (e.g. unsupported language_code) -> ServiceInputError,
-        # and the account must not be remembered as tier-limited
-        responses = [self._resp(400, text='bad language_code'), self._resp(400, text='bad language_code')]
+        # 400 (e.g. unsupported language_code) is an input error, not a tier
+        # problem: surface ServiceInputError immediately without a 128 kbps retry
         with patch('hypertts_addon.services.service_elevenlabscustom.requests.post',
-                   side_effect=responses):
+                   return_value=self._resp(400, text='bad language_code')) as mock_post:
             with self.assertRaises(errors.ServiceInputError):
                 service.get_tts_audio('Hello', voice, {})
+        self.assertEqual(len(self._urls(mock_post)), 1)
         self.assertFalse(service._mp3_hq_unsupported)
 
 


### PR DESCRIPTION
## Comparison

Difference in audio quality is pretty minor, but I can hear a difference in the quality of resonance between the recordings. Check it out (with headphones).

[Charlotte_192kbps.mp3](https://github.com/user-attachments/files/29900850/Charlotte_192kbps.mp3)
[Charlotte_128kbps.mp3](https://github.com/user-attachments/files/29900851/Charlotte_128kbps.mp3)


## Commentary

It's a pretty minor difference but is an upgrade nonetheless. It also doesn't affect billing if you have the creator tier. I wouldn't be offended if you didn't take it due to the complexity difference.

The rest of the PR description was written by Claude. Apologies for the em-dashes.

## What

ElevenLabs mp3 output currently uses the API default of **128 kbps** (`mp3_44100_128`) because no `output_format` is sent for the mp3 case. This requests **192 kbps** (`mp3_44100_192`) instead, matching the quality of the ogg path which already requests `opus_48000_192`. Applies to both the managed **ElevenLabs** service and **ElevenLabsCustom**.

192 kbps mp3 requires an ElevenLabs **Creator tier or above**, so lower tiers must keep getting 128 kbps.

## How

`_request_mp3_audio` requests 192 kbps and transparently falls back to the universally-available 128 kbps when the account tier rejects it.

Verified against the live ElevenLabs API — a tier that can't use 192 kbps returns:
```
HTTP 403  {"detail":{"code":"subscription_required","status":"output_format_not_allowed",
           "message":"Output format 'mp3_44100_192' is only available on the Creator tier and above."}}
```
So the fallback triggers specifically on **403**; every other error (401 quota/auth, 402 paid-plan, 400 input, 429 rate-limit, 5xx) surfaces immediately unchanged — a lower bitrate can't fix those. As a safety net, the account is only remembered as tier-limited when the 128 kbps retry actually succeeds.

- The tier-limited result is cached per configuration (`_mp3_hq_unsupported`); after the first fallback, requests go straight to 128 kbps. Reset on `configure()` so an upgrade / key change re-probes.
- The **ogg path** and existing **error mapping** (including the 400 `ServiceInputError` case in ElevenLabsCustom) are unchanged.
- No provider cost change — ElevenLabs bills per character, not per bitrate; only the audio files get larger.

## Testing

Validated live end-to-end across account tiers:
- **Creator**: 192 kbps returned on the first request, no fallback.
- **Free / tier-limited**: 403 on 192 kbps → fell back to 128 kbps → cached; second call skipped the probe. Confirmed with an A/B listening test (192 vs 128 vs a 64 kbps anchor) and by parsing the encoded frame bitrate of each file.
- **Deprecated model on free tier** (401 `model_deprecated_free_tier`): surfaced immediately as `ServicePermissionError` with no spurious retry.

Adds mocked unit tests in `test_elevenlabs.py` covering: 192 success, 403 → 128 fallback + caching, cached-skip-to-128, non-tier errors surfaced in a single request, and the ogg path — for both ElevenLabs and ElevenLabsCustom. Existing quota / paid-plan / 500 error-mapping tests still pass.