### PR TITLE
Improve Google Cloud TTS & Gemini mp3 quality (32 kbps → 128 kbps)

### DIFF
--- a/hypertts_addon/audio_utils.py
+++ b/hypertts_addon/audio_utils.py
@@ -1,0 +1,53 @@
+import io
+import os
+import wave
+import tempfile
+import subprocess
+
+from hypertts_addon import logging_utils
+logger = logging_utils.get_child_logger(__name__)
+
+
+def pcm_to_wav_bytes(pcm_bytes, sample_rate, channels=1, sample_width=2):
+    """Wrap raw little-endian PCM samples in a WAV (RIFF) container in memory."""
+    buffer = io.BytesIO()
+    with wave.open(buffer, 'wb') as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm_bytes)
+    return buffer.getvalue()
+
+
+def encode_wav_to_mp3(wav_bytes, bitrate_kbps):
+    """Encode WAV audio to MP3 at a fixed CBR bitrate using Anki's bundled lame.
+
+    Anki's own aqt.sound._encode_mp3 invokes lame with no bitrate argument, so
+    it falls back to lame's default (32 kbps for a 24 kHz mono source). We want
+    a specific, higher bitrate, so we build the lame command ourselves and reuse
+    Anki's helpers to resolve the bundled binary (_packagedCmd) and to run it
+    (retryWait / startup_info).
+    """
+    import aqt.sound
+    import aqt.utils
+
+    wav_fh, wav_path = tempfile.mkstemp(prefix='hypertts_', suffix='.wav')
+    os.close(wav_fh)
+    mp3_fh, mp3_path = tempfile.mkstemp(prefix='hypertts_', suffix='.mp3')
+    os.close(mp3_fh)
+    try:
+        with open(wav_path, 'wb') as f:
+            f.write(wav_bytes)
+        cmd = ['lame', wav_path, mp3_path, '--noreplaygain', '--quiet', '-b', str(bitrate_kbps)]
+        cmd, env = aqt.sound._packagedCmd(cmd)
+        retcode = aqt.sound.retryWait(subprocess.Popen(cmd, startupinfo=aqt.utils.startup_info(), env=env))
+        if retcode != 0:
+            raise Exception(f'lame mp3 encoding failed (exit code {retcode}) for command: {" ".join(cmd)}')
+        with open(mp3_path, 'rb') as f:
+            return f.read()
+    finally:
+        for path in (wav_path, mp3_path):
+            try:
+                os.remove(path)
+            except OSError:
+                pass

--- a/hypertts_addon/audio_utils.py
+++ b/hypertts_addon/audio_utils.py
@@ -4,6 +4,7 @@ import wave
 import tempfile
 import subprocess
 
+from hypertts_addon import errors
 from hypertts_addon import logging_utils
 logger = logging_utils.get_child_logger(__name__)
 
@@ -40,7 +41,15 @@ def encode_wav_to_mp3(wav_bytes, bitrate_kbps):
             f.write(wav_bytes)
         cmd = ['lame', wav_path, mp3_path, '--noreplaygain', '--quiet', '-b', str(bitrate_kbps)]
         cmd, env = aqt.sound._packagedCmd(cmd)
-        retcode = aqt.sound.retryWait(subprocess.Popen(cmd, startupinfo=aqt.utils.startup_info(), env=env))
+        try:
+            process = subprocess.Popen(cmd, startupinfo=aqt.utils.startup_info(), env=env)
+        except FileNotFoundError as e:
+            # The lame binary is bundled on Windows/macOS but may be absent on
+            # Linux. Surface an actionable, non-retryable HyperTTSError instead
+            # of a raw OSError (which would be mis-reported to Sentry as a crash).
+            logger.warning(f'lame mp3 encoder not found: {e}')
+            raise errors.Mp3EncoderNotFound() from e
+        retcode = aqt.sound.retryWait(process)
         if retcode != 0:
             raise Exception(f'lame mp3 encoding failed (exit code {retcode}) for command: {" ".join(cmd)}')
         with open(mp3_path, 'rb') as f:

--- a/hypertts_addon/constants.py
+++ b/hypertts_addon/constants.py
@@ -17,6 +17,13 @@ RequestTimeoutShort = 3
 BATCH_RETRY_DELAYS = [1, 2, 4]
 BATCH_RETRY_MAX = 3
 
+# Bitrate used when re-encoding lossless audio (Google LINEAR16, Gemini PCM) to
+# MP3. Google/Gemini only emit MP3 at ~32 kbps, so we request lossless and
+# re-encode at this bitrate for much better quality while staying MP3 (OGG is
+# not supported by the iOS Anki client). 24 kHz mono source -> 128 kbps is
+# generous headroom.
+AUDIO_MP3_ENCODE_BITRATE_KBPS = 128
+
 CLOUDLANGUAGETOOLS_API_BASE_URL = 'https://cloudlanguagetools-api.vocab.ai'
 VOCABAI_API_BASE_URL = 'https://app.vocab.ai'
 

--- a/hypertts_addon/errors.py
+++ b/hypertts_addon/errors.py
@@ -186,6 +186,15 @@ class MissingGraphicsFile(HyperTTSError):
         super().__init__(message)
 
 
+class Mp3EncoderNotFound(HyperTTSError):
+    def __init__(self):
+        message = ('The lame MP3 encoder could not be found, so MP3 audio cannot be generated. '
+                   'lame is bundled with Anki on Windows and macOS, but on Linux it must be installed '
+                   'separately, for example "sudo apt install lame" (or your distribution\'s equivalent). '
+                   'Install it and restart Anki.')
+        super().__init__(message)
+
+
 class RequestError(HyperTTSError):
     def __init__(self, source_text, voice, error_message):
         message = f'Could not request audio for [{source_text}]: {error_message} (voice: {voice})'

--- a/hypertts_addon/services/service_gemini.py
+++ b/hypertts_addon/services/service_gemini.py
@@ -1,11 +1,7 @@
-import os
 import json
 import math
-import wave
 import base64
-import tempfile
 import requests
-import aqt.sound
 
 
 from hypertts_addon import voice as voice_module
@@ -13,6 +9,7 @@ from hypertts_addon import service
 from hypertts_addon import errors
 from hypertts_addon import constants
 from hypertts_addon import options
+from hypertts_addon import audio_utils
 from hypertts_addon import logging_utils
 logger = logging_utils.get_child_logger(__name__)
 
@@ -218,22 +215,9 @@ class Gemini(service.ServiceBase):
 
     def _encode_pcm_to_mp3(self, pcm_bytes):
         # Gemini returns raw signed little-endian PCM at 24kHz / 16-bit / mono.
-        # Per PCM_TO_MP3.md: wrap the bytes in a WAV container via stdlib `wave`,
-        # then hand off to Anki's bundled `lame` via aqt.sound._encode_mp3.
-        wav_fh, wav_path = tempfile.mkstemp(prefix='hypertts_gemini_', suffix='.wav')
-        os.close(wav_fh)
-        mp3_fh, mp3_path = tempfile.mkstemp(prefix='hypertts_gemini_', suffix='.mp3')
-        os.close(mp3_fh)
-        try:
-            with wave.open(wav_path, 'wb') as w:
-                w.setnchannels(1)
-                w.setsampwidth(2)
-                w.setframerate(24000)
-                w.writeframes(pcm_bytes)
-            aqt.sound._encode_mp3(wav_path, mp3_path)
-            with open(mp3_path, 'rb') as f:
-                return f.read()
-        finally:
-            for p in (wav_path, mp3_path):
-                if os.path.exists(p):
-                    os.remove(p)
+        # Wrap it in a WAV container and encode to MP3 at our target bitrate.
+        # (Anki's own aqt.sound._encode_mp3 passes no bitrate to lame, so it
+        # defaults to ~32 kbps for this 24 kHz mono source, which is noticeably
+        # lossy — encode_wav_to_mp3 sets an explicit, higher bitrate instead.)
+        wav_bytes = audio_utils.pcm_to_wav_bytes(pcm_bytes, sample_rate=24000)
+        return audio_utils.encode_wav_to_mp3(wav_bytes, constants.AUDIO_MP3_ENCODE_BITRATE_KBPS)

--- a/hypertts_addon/services/service_google.py
+++ b/hypertts_addon/services/service_google.py
@@ -9,6 +9,7 @@ from hypertts_addon import service
 from hypertts_addon import errors
 from hypertts_addon import constants
 from hypertts_addon import options
+from hypertts_addon import audio_utils
 from hypertts_addon import logging_utils
 logger = logging_utils.get_child_logger(__name__)
 
@@ -55,8 +56,12 @@ class Google(service.ServiceBase):
 
         audio_format_str = voice_options.get(options.AUDIO_FORMAT_PARAMETER, options.AudioFormat.mp3.name)
         audio_format = options.AudioFormat[audio_format_str]
+        # Google's native MP3 encoding is a fixed ~32 kbps, noticeably lossy
+        # (especially for tonal languages). For mp3 output we instead request
+        # lossless LINEAR16 and re-encode locally at a higher bitrate. OGG Opus
+        # is already good quality and returned directly.
         audio_format_map = {
-            options.AudioFormat.mp3: 'MP3',
+            options.AudioFormat.mp3: 'LINEAR16',
             options.AudioFormat.ogg_opus: 'OGG_OPUS'
         }
 
@@ -122,5 +127,10 @@ class Google(service.ServiceBase):
         data = response.json()
         encoded = data['audioContent']
         audio_content = base64.b64decode(encoded)
+
+        # LINEAR16 comes back as a lossless WAV; re-encode to MP3 at our target
+        # bitrate so the user gets a much better mp3 than Google's native ~32 kbps.
+        if audio_format == options.AudioFormat.mp3:
+            audio_content = audio_utils.encode_wav_to_mp3(audio_content, constants.AUDIO_MP3_ENCODE_BITRATE_KBPS)
 
         return audio_content

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,84 @@
+import io
+import sys
+import types
+import wave
+import unittest
+from unittest import mock
+
+# audio_utils imports hypertts_addon (which skips the anki import under pytest)
+if not hasattr(sys, '_pytest_mode'):
+    sys._pytest_mode = True
+from hypertts_addon import audio_utils
+
+
+class TestPcmToWavBytes(unittest.TestCase):
+
+    def test_wraps_pcm_in_riff_wav(self):
+        pcm = b'\x00\x01' * 100
+        data = audio_utils.pcm_to_wav_bytes(pcm, sample_rate=24000)
+        self.assertEqual(data[:4], b'RIFF')
+        self.assertEqual(data[8:12], b'WAVE')
+        with wave.open(io.BytesIO(data)) as w:
+            self.assertEqual(w.getnchannels(), 1)
+            self.assertEqual(w.getsampwidth(), 2)
+            self.assertEqual(w.getframerate(), 24000)
+            self.assertEqual(w.readframes(w.getnframes()), pcm)
+
+
+class TestEncodeWavToMp3(unittest.TestCase):
+    """Verify the lame command is built with the requested bitrate, without
+    needing a real Anki install or lame binary."""
+
+    def test_invokes_lame_with_bitrate(self):
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured['cmd'] = cmd
+            with open(cmd[2], 'wb') as f:  # cmd[2] is the mp3 destination path
+                f.write(b'FAKEMP3')
+            proc = mock.Mock()
+            proc.wait.return_value = 0
+            return proc
+
+        fake_sound = types.ModuleType('aqt.sound')
+        fake_sound._packagedCmd = lambda c: (c, {})
+        fake_sound.retryWait = lambda p: p.wait()
+        fake_utils = types.ModuleType('aqt.utils')
+        fake_utils.startup_info = lambda: None
+        fake_aqt = types.ModuleType('aqt')
+        fake_aqt.sound = fake_sound
+        fake_aqt.utils = fake_utils
+
+        with mock.patch.dict('sys.modules', {'aqt': fake_aqt, 'aqt.sound': fake_sound, 'aqt.utils': fake_utils}), \
+             mock.patch('hypertts_addon.audio_utils.subprocess.Popen', side_effect=fake_popen):
+            out = audio_utils.encode_wav_to_mp3(b'RIFFxxxxWAVE', 128)
+
+        self.assertEqual(out, b'FAKEMP3')
+        self.assertEqual(captured['cmd'][0], 'lame')
+        self.assertIn('-b', captured['cmd'])
+        self.assertIn('128', captured['cmd'])
+        self.assertIn('--quiet', captured['cmd'])
+
+    def test_raises_when_lame_fails(self):
+        def fake_popen(cmd, **kwargs):
+            proc = mock.Mock()
+            proc.wait.return_value = 1  # non-zero exit
+            return proc
+
+        fake_sound = types.ModuleType('aqt.sound')
+        fake_sound._packagedCmd = lambda c: (c, {})
+        fake_sound.retryWait = lambda p: p.wait()
+        fake_utils = types.ModuleType('aqt.utils')
+        fake_utils.startup_info = lambda: None
+        fake_aqt = types.ModuleType('aqt')
+        fake_aqt.sound = fake_sound
+        fake_aqt.utils = fake_utils
+
+        with mock.patch.dict('sys.modules', {'aqt': fake_aqt, 'aqt.sound': fake_sound, 'aqt.utils': fake_utils}), \
+             mock.patch('hypertts_addon.audio_utils.subprocess.Popen', side_effect=fake_popen):
+            with self.assertRaises(Exception):
+                audio_utils.encode_wav_to_mp3(b'RIFFxxxxWAVE', 128)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -59,6 +59,31 @@ class TestEncodeWavToMp3(unittest.TestCase):
         self.assertIn('128', captured['cmd'])
         self.assertIn('--quiet', captured['cmd'])
 
+    def test_missing_lame_raises_clear_error(self):
+        # On Linux without lame installed, Popen raises FileNotFoundError; this
+        # must surface as an actionable HyperTTSError (not a raw OSError, which
+        # would be mis-reported to Sentry as a crash).
+        from hypertts_addon import errors
+
+        def fake_popen(cmd, **kwargs):
+            raise FileNotFoundError(2, 'No such file or directory', 'lame')
+
+        fake_sound = types.ModuleType('aqt.sound')
+        fake_sound._packagedCmd = lambda c: (c, {})
+        fake_sound.retryWait = lambda p: p.wait()
+        fake_utils = types.ModuleType('aqt.utils')
+        fake_utils.startup_info = lambda: None
+        fake_aqt = types.ModuleType('aqt')
+        fake_aqt.sound = fake_sound
+        fake_aqt.utils = fake_utils
+
+        with mock.patch.dict('sys.modules', {'aqt': fake_aqt, 'aqt.sound': fake_sound, 'aqt.utils': fake_utils}), \
+             mock.patch('hypertts_addon.audio_utils.subprocess.Popen', side_effect=fake_popen):
+            with self.assertRaises(errors.Mp3EncoderNotFound) as ctx:
+                audio_utils.encode_wav_to_mp3(b'RIFFxxxxWAVE', 128)
+        self.assertIn('lame', str(ctx.exception).lower())
+        self.assertIsInstance(ctx.exception, errors.HyperTTSError)
+
     def test_raises_when_lame_fails(self):
         def fake_popen(cmd, **kwargs):
             proc = mock.Mock()

--- a/tests/test_tts_services/test_gemini.py
+++ b/tests/test_tts_services/test_gemini.py
@@ -285,3 +285,44 @@ class TestGeminiErrorStatusMapping(unittest.TestCase):
                 with self.assertRaises(expected_cls) as ctx:
                     _raise_for_error_status(status, '{}', self.SOURCE_TEXT, self.VOICE)
                 self.assertIsInstance(ctx.exception, errors.ServiceRequestError)
+
+
+class TestGeminiMp3Bitrate(unittest.TestCase):
+    """Mock test: Gemini's raw PCM is re-encoded to mp3 at the configured bitrate.
+
+    Previously the PCM was handed to aqt.sound._encode_mp3, which passes no
+    bitrate to lame and so defaulted to ~32 kbps for the 24 kHz mono source.
+    """
+
+    def _voice(self):
+        return voice_module.TtsVoice_v3(
+            name='Test', voice_key={'name': 'Orus'},
+            options={'model': {'type': 'list', 'values': ['gemini-2.5-flash-tts'], 'default': 'gemini-2.5-flash-tts'},
+                     'prompt': {'type': 'text', 'default': ''},
+                     'language_code': {'type': 'text', 'default': 'en-US'}},
+            service='Gemini', gender=constants.Gender.Male,
+            audio_languages=[languages.AudioLanguage.en_US], service_fee=constants.ServiceFee.paid)
+
+    def test_pcm_reencoded_at_target_bitrate(self):
+        # pytest tests/test_tts_services/test_gemini.py -k 'test_pcm_reencoded_at_target_bitrate'
+        import base64
+        from unittest import mock
+        from hypertts_addon.services.service_gemini import Gemini
+
+        service = Gemini()
+        service.configure({'api_key': 'fake_key'})
+
+        resp = mock.Mock()
+        resp.status_code = 200
+        resp.json.return_value = {'candidates': [{'content': {'parts': [
+            {'inlineData': {'data': base64.b64encode(b'\x00\x01' * 2400).decode()}}]}}]}
+
+        with mock.patch('hypertts_addon.services.service_gemini.requests.post', return_value=resp), \
+             mock.patch('hypertts_addon.services.service_gemini.audio_utils.encode_wav_to_mp3',
+                        return_value=b'MP3BYTES') as mock_encode:
+            out = service.get_tts_audio('hello', self._voice(), {})
+
+        self.assertEqual(out, b'MP3BYTES')
+        self.assertEqual(mock_encode.call_args.args[1], constants.AUDIO_MP3_ENCODE_BITRATE_KBPS)
+        # the encoder receives a WAV container built from the raw PCM
+        self.assertEqual(mock_encode.call_args.args[0][:4], b'RIFF')

--- a/tests/test_tts_services/test_google.py
+++ b/tests/test_tts_services/test_google.py
@@ -1,4 +1,7 @@
 import copy
+import base64
+import unittest
+from unittest import mock
 
 from .base import TTSTests, logger
 from hypertts_addon import constants
@@ -65,6 +68,60 @@ class TestGoogle(TTSTests):
             assert e.voice.service == 'Google'
             exception_caught = True
         assert exception_caught
+
+
+class TestGoogleMp3Reencode(unittest.TestCase):
+    """Mock tests: mp3 output requests lossless LINEAR16 and re-encodes locally.
+
+    Google's native MP3 is a fixed ~32 kbps; we request LINEAR16 and re-encode
+    at constants.AUDIO_MP3_ENCODE_BITRATE_KBPS so the user gets a better mp3.
+    """
+
+    def _voice(self):
+        return voice_module.TtsVoice_v3(
+            name='Test', voice_key={'name': 'en-US-Standard-A', 'language_code': 'en-US'},
+            options={'speaking_rate': {'type': 'number', 'min': 0.25, 'max': 4.0, 'default': 1.0}},
+            service='Google', gender=constants.Gender.Male,
+            audio_languages=[languages.AudioLanguage.en_US], service_fee=constants.ServiceFee.paid)
+
+    def _resp(self, raw_bytes):
+        r = mock.Mock()
+        r.status_code = 200
+        r.json.return_value = {'audioContent': base64.b64encode(raw_bytes).decode()}
+        return r
+
+    def test_mp3_requests_linear16_and_reencodes(self):
+        # pytest tests/test_tts_services/test_google.py -k 'test_mp3_requests_linear16_and_reencodes'
+        from hypertts_addon.services.service_google import Google
+        service = Google()
+        service.configure({'api_key': 'fake_key'})
+
+        with mock.patch('hypertts_addon.services.service_google.requests.post',
+                        return_value=self._resp(b'RIFF....WAVE....')) as mock_post, \
+             mock.patch('hypertts_addon.services.service_google.audio_utils.encode_wav_to_mp3',
+                        return_value=b'MP3BYTES') as mock_encode:
+            out = service.get_tts_audio('hello', self._voice(), {})
+
+        self.assertEqual(mock_post.call_args.kwargs['json']['audioConfig']['audioEncoding'], 'LINEAR16')
+        self.assertEqual(out, b'MP3BYTES')
+        # the lossless WAV is handed to the encoder at the configured bitrate
+        self.assertEqual(mock_encode.call_args.args[0], b'RIFF....WAVE....')
+        self.assertEqual(mock_encode.call_args.args[1], constants.AUDIO_MP3_ENCODE_BITRATE_KBPS)
+
+    def test_ogg_opus_returned_directly(self):
+        # pytest tests/test_tts_services/test_google.py -k 'test_ogg_opus_returned_directly'
+        from hypertts_addon.services.service_google import Google
+        service = Google()
+        service.configure({'api_key': 'fake_key'})
+
+        with mock.patch('hypertts_addon.services.service_google.requests.post',
+                        return_value=self._resp(b'OGGDATA')) as mock_post, \
+             mock.patch('hypertts_addon.services.service_google.audio_utils.encode_wav_to_mp3') as mock_encode:
+            out = service.get_tts_audio('hi', self._voice(), {'format': 'ogg_opus'})
+
+        self.assertEqual(mock_post.call_args.kwargs['json']['audioConfig']['audioEncoding'], 'OGG_OPUS')
+        self.assertEqual(out, b'OGGDATA')
+        self.assertFalse(mock_encode.called)
 
 
 class TestGoogleCLT(TestGoogle):


### PR DESCRIPTION
## Problem

A user reported that Google **Chirp3-HD** voices sound noticeably worse in HyperTTS than in the Google Cloud console — especially for tonal languages like Thai. Investigation confirmed it: Google delivers **32 kbps MP3**.

- **Google Cloud TTS** returns MP3 at a fixed **~32 kbps** (Google's native MP3 encoding; there is no bitrate control).
- **Gemini** returns lossless 24 kHz PCM, but the service handed it to Anki's `aqt.sound._encode_mp3`, which passes *no* bitrate to lame and so also defaults to **~32 kbps**.

32 kbps mono is audibly lossy (smeared sibilants, degraded tones).

## Why re-encode instead of just asking for a better format

- Google's MP3 bitrate is **not configurable** — 32 kbps is all it gives.
- **OGG Opus** would be ideal (small + high quality) and is already supported, but it is **not playable on the iOS Anki client**, so it can't be the cross-platform default.

So the only way to a better *MP3* is to request **lossless** audio and re-encode locally at a proper bitrate.

## Change

- **Google Cloud TTS**: for mp3 output, request **LINEAR16** (lossless WAV) and re-encode to MP3. OGG Opus is unchanged (returned directly).
- **Gemini**: wrap its PCM in WAV and encode at the same bitrate (instead of lame's 32 kbps default).
- New `hypertts_addon/audio_utils.py` (`pcm_to_wav_bytes`, `encode_wav_to_mp3`) reuses Anki's bundled lame via `_packagedCmd` with an explicit `-b`. Bitrate is one constant, `constants.AUDIO_MP3_ENCODE_BITRATE_KBPS = 128`.

### Why 128 kbps
The source is **24 kHz mono**. MP3 at ≤32 kHz uses MPEG-2 Layer III, which **caps at 160 kbps** (192/256/320 require a 44.1/48 kHz source — lame clamps them to 160 here). For 12 kHz-bandwidth mono speech, MP3 is perceptually transparent by ~96–128 kbps, so 128 sits comfortably past transparency with headroom, at 1/3 the size of the 384 kbps lossless PCM. Going higher only adds file size.

### lame dependency
The re-encode needs lame. It is **bundled with Anki on Windows/macOS**; on **Linux** it may need to be installed separately (`sudo apt install lame`). Gemini already depended on lame; this extends it to Google. If lame is absent, the code now raises a clear, actionable `errors.Mp3EncoderNotFound` (a `HyperTTSError`, so it's shown to the user, **not** reported to Sentry as a crash, and not retried) instead of a raw `FileNotFoundError`.

## Trade-offs
- MP3 files are ~4× larger than the old 32 kbps output (still ~1/3 of lossless WAV). For Google, the LINEAR16 download is larger and there's a local lame encode per clip.
- Note for maintainers: this is client-side, so **HyperTTS Pro / cloudlanguagetools** users (who route Google/Gemini through the vocab.ai backend) won't benefit unless the backend applies the same treatment.

## Testing
- Verified **end-to-end against the live APIs**: real `th-TH-Chirp3-HD-Orus`, `en-US-Chirp3-HD-Kore`, and Gemini Orus/Kore voices now produce `MPEG layer III, 128 kbps, 24 kHz mono` (was 32 kbps); Google `ogg_opus` unchanged.
- Added mock unit tests for both services and for `audio_utils` (including the missing-lame → `Mp3EncoderNotFound` path).

## Audio samples

Same voice and text in each pair — only the bitrate differs. The **Thai ·
Google Chirp Orus** row is the exact case from the original report. "After"
files are `MPEG layer III, 128 kbps, 24 kHz mono`; "before" is the current
32 kbps output.

| Language | Service · Voice | Before — 32 kbps (current) | After — 128 kbps (this PR) |
|----------|-----------------|----------------------------|----------------------------|
| Thai | Google Chirp3‑HD · Orus | [th_google_chirp_orus_BEFORE_32k.mp3](https://github.com/user-attachments/files/29905710/th_google_chirp_orus_BEFORE_32k.mp3) | [th_google_chirp_orus_AFTER_128k.mp3](https://github.com/user-attachments/files/29905714/th_google_chirp_orus_AFTER_128k.mp3) |
| English | Google Chirp3‑HD · Kore | [en_google_chirp_kore_BEFORE_32k.mp3](https://github.com/user-attachments/files/29905736/en_google_chirp_kore_BEFORE_32k.mp3) | [en_google_chirp_kore_AFTER_128k.mp3](https://github.com/user-attachments/files/29905745/en_google_chirp_kore_AFTER_128k.mp3) |
| Thai | Gemini · Orus | [th_gemini_orus_BEFORE_32k.mp3](https://github.com/user-attachments/files/29905778/th_gemini_orus_BEFORE_32k.mp3) | [th_gemini_orus_AFTER_128k.mp3](https://github.com/user-attachments/files/29905786/th_gemini_orus_AFTER_128k.mp3) |
| English | Gemini · Kore | [en_gemini_kore_BEFORE_32k.mp3](https://github.com/user-attachments/files/29905795/en_gemini_kore_BEFORE_32k.mp3) |  [en_gemini_kore_AFTER_128k.mp3](https://github.com/user-attachments/files/29905802/en_gemini_kore_AFTER_128k.mp3) |