### PR TITLE
Add Mistral Voxtral text-to-speech service

### DIFF
--- a/hypertts_addon/services/service_mistral.py
+++ b/hypertts_addon/services/service_mistral.py
@@ -1,0 +1,138 @@
+import base64
+import requests
+
+
+from hypertts_addon import voice
+from hypertts_addon import service
+from hypertts_addon import errors
+from hypertts_addon import constants
+from hypertts_addon import options
+from hypertts_addon import logging_utils
+logger = logging_utils.get_child_logger(__name__)
+
+
+class Mistral(service.ServiceBase):
+    CONFIG_API_KEY = 'api_key'
+    DEFAULT_MODEL = 'voxtral-mini-tts-2603'
+
+    def __init__(self):
+        service.ServiceBase.__init__(self)
+
+    def cloudlanguagetools_enabled(self):
+        return False
+
+    @property
+    def service_type(self) -> constants.ServiceType:
+        return constants.ServiceType.tts
+
+    @property
+    def service_fee(self) -> constants.ServiceFee:
+        return constants.ServiceFee.paid
+
+    def configuration_options(self):
+        return {
+            self.CONFIG_API_KEY: str
+        }
+
+    def configure(self, config):
+        self._config = config
+        self.api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
+
+    def voice_list(self):
+        return self.basic_voice_list()
+
+    def get_tts_audio(self, source_text, voice: voice.VoiceBase, voice_options):
+        api_key = self.get_configuration_value_mandatory(self.CONFIG_API_KEY)
+
+        model = voice_options.get('model', voice.options['model']['default'])
+        audio_format_str = voice_options.get(
+            options.AUDIO_FORMAT_PARAMETER,
+            voice.options.get(options.AUDIO_FORMAT_PARAMETER, {}).get(
+                'default', options.AudioFormat.mp3.name
+            ),
+        )
+        audio_format = options.AudioFormat[audio_format_str]
+
+        # Mistral supports mp3, wav, pcm, flac, opus. HyperTTS's audio pipeline
+        # verifies output against Ogg-wrapped Opus for AudioFormat.ogg_opus, but
+        # Mistral returns raw Opus (no Ogg container), so we only expose mp3
+        # here. Any other format is rejected as a permanent input error rather
+        # than being silently swapped.
+        audio_format_map = {
+            options.AudioFormat.mp3: 'mp3',
+        }
+        if audio_format not in audio_format_map:
+            raise errors.ServiceInputError(
+                source_text,
+                voice,
+                f'Mistral does not support audio format {audio_format.name}',
+            )
+        response_format = audio_format_map[audio_format]
+
+        url = 'https://api.mistral.ai/v1/audio/speech'
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        }
+        data = {
+            'model': model,
+            'input': source_text,
+            'voice_id': voice.voice_key['voice_id'],
+            'response_format': response_format,
+        }
+
+        response = requests.post(
+            url, json=data, headers=headers, timeout=constants.RequestTimeout
+        )
+
+        if response.status_code != 200:
+            logger.warning(f'Mistral response content: {response.text}')
+            logger.warning(
+                f'Mistral response status: {response.status_code} '
+                f'headers: {dict(response.headers)}'
+            )
+
+        if response.status_code == 429:
+            raise errors.RateLimitError(
+                source_text,
+                voice,
+                f'Mistral rate limit: {response.status_code} {response.text}',
+            )
+
+        # 403 groups with 401: Mistral returns 403 for both invalid keys and
+        # moderated / rejected content — neither is retryable.
+        if response.status_code in (401, 403):
+            raise errors.ServicePermissionError(
+                source_text,
+                voice,
+                f'Mistral authentication or permission failed: '
+                f'{response.status_code} {response.text}',
+            )
+
+        # 400 must be PermanentError so batch retry stops (mirrors the OpenAI
+        # service fix for Sentry ANKI-HYPER-TTS-JRS).
+        if response.status_code == 400:
+            raise errors.ServiceInputError(
+                source_text,
+                voice,
+                f'Mistral bad request: {response.status_code} {response.text}',
+            )
+
+        response.raise_for_status()
+
+        # Documented non-streaming response is a JSON envelope with base64
+        # audio; accept raw audio bytes too in case the endpoint returns that.
+        content_type = response.headers.get('Content-Type', '').lower()
+        if 'application/json' in content_type:
+            payload = response.json()
+            encoded = payload.get('audio_data')
+            if not encoded:
+                raise errors.RequestError(
+                    source_text,
+                    voice,
+                    f'Mistral response missing audio_data field: {payload}',
+                )
+            return base64.b64decode(encoded)
+
+        return response.content

--- a/hypertts_addon/services/voicelist.py
+++ b/hypertts_addon/services/voicelist.py
@@ -54723,3 +54723,49 @@ VOICE_LIST = [
             service_fee=constants.ServiceFee.paid
         )
 ]
+
+
+_MISTRAL_VOICE_OPTIONS = {
+    'model': {
+        'type': 'list',
+        'values': ['voxtral-mini-tts-2603'],
+        'default': 'voxtral-mini-tts-2603',
+    },
+}
+
+
+_MISTRAL_VOICES = [
+    ('casual_male',      'Casual (Male)',      constants.Gender.Male,   languages.AudioLanguage.en_US),
+    ('casual_female',    'Casual (Female)',    constants.Gender.Female, languages.AudioLanguage.en_US),
+    ('cheerful_female',  'Cheerful (Female)',  constants.Gender.Female, languages.AudioLanguage.en_US),
+    ('neutral_male',     'Neutral (Male)',     constants.Gender.Male,   languages.AudioLanguage.en_US),
+    ('neutral_female',   'Neutral (Female)',   constants.Gender.Female, languages.AudioLanguage.en_US),
+    ('fr_male',          'French (Male)',      constants.Gender.Male,   languages.AudioLanguage.fr_FR),
+    ('fr_female',        'French (Female)',    constants.Gender.Female, languages.AudioLanguage.fr_FR),
+    ('es_male',          'Spanish (Male)',     constants.Gender.Male,   languages.AudioLanguage.es_ES),
+    ('es_female',        'Spanish (Female)',   constants.Gender.Female, languages.AudioLanguage.es_ES),
+    ('de_male',          'German (Male)',      constants.Gender.Male,   languages.AudioLanguage.de_DE),
+    ('de_female',        'German (Female)',    constants.Gender.Female, languages.AudioLanguage.de_DE),
+    ('it_male',          'Italian (Male)',     constants.Gender.Male,   languages.AudioLanguage.it_IT),
+    ('it_female',        'Italian (Female)',   constants.Gender.Female, languages.AudioLanguage.it_IT),
+    ('pt_male',          'Portuguese (Male)',  constants.Gender.Male,   languages.AudioLanguage.pt_PT),
+    ('pt_female',        'Portuguese (Female)', constants.Gender.Female, languages.AudioLanguage.pt_PT),
+    ('nl_male',          'Dutch (Male)',       constants.Gender.Male,   languages.AudioLanguage.nl_NL),
+    ('nl_female',        'Dutch (Female)',     constants.Gender.Female, languages.AudioLanguage.nl_NL),
+    ('ar_male',          'Arabic (Male)',      constants.Gender.Male,   languages.AudioLanguage.ar_XA),
+    ('hi_male',          'Hindi (Male)',       constants.Gender.Male,   languages.AudioLanguage.hi_IN),
+    ('hi_female',        'Hindi (Female)',     constants.Gender.Female, languages.AudioLanguage.hi_IN),
+]
+
+for _voice_id, _display_name, _gender, _audio_language in _MISTRAL_VOICES:
+    VOICE_LIST.append(
+        voice.TtsVoice_v3(
+            name=_display_name,
+            voice_key={'voice_id': _voice_id},
+            options=_MISTRAL_VOICE_OPTIONS,
+            service='Mistral',
+            gender=_gender,
+            audio_languages=[_audio_language],
+            service_fee=constants.ServiceFee.paid,
+        )
+    )

--- a/tests/test_tts_services/base.py
+++ b/tests/test_tts_services/base.py
@@ -133,6 +133,11 @@ class TTSTests(unittest.TestCase):
         self.manager.get_service('OpenAI').configure({
             'api_key': os.environ['OPENAI_API_KEY']
         })
+        # mistral
+        self.manager.get_service('Mistral').enabled = True
+        self.manager.get_service('Mistral').configure({
+            'api_key': os.environ['MISTRAL_API_KEY']
+        })
         # forvo
         self.manager.get_service('Forvo').enabled = True
         self.manager.get_service('Forvo').configure({

--- a/tests/test_tts_services/test_mistral.py
+++ b/tests/test_tts_services/test_mistral.py
@@ -1,0 +1,121 @@
+import base64
+import unittest
+import unittest.mock as mock
+
+from .base import TTSTests, logger
+from hypertts_addon import languages
+from hypertts_addon import errors
+from hypertts_addon import options
+from hypertts_addon.languages import AudioLanguage
+from hypertts_addon.services import service_mistral
+
+
+class TestMistral(TTSTests):
+
+    def test_mistral_english(self):
+        # pytest tests/test_tts_services/ -k 'TestMistral and test_mistral_english'
+        service_name = 'Mistral'
+
+        voice_list = self.manager.full_voice_list()
+        service_voices = [voice for voice in voice_list if voice.service == service_name]
+        assert len(service_voices) >= 5
+
+        self.random_voice_test(service_name, AudioLanguage.en_US, 'This is the first sentence')
+
+    def test_mistral_french(self):
+        # pytest tests/test_tts_services/ -k 'TestMistral and test_mistral_french'
+        self.random_voice_test('Mistral', AudioLanguage.fr_FR, 'Il va pleuvoir demain.')
+
+
+class TestMistralErrorHandling(unittest.TestCase):
+
+    def setUp(self):
+        self.service = service_mistral.Mistral()
+        self.service._config = {'api_key': 'fake_key'}
+        self.service.api_key = 'fake_key'
+
+        self.mock_voice = mock.Mock()
+        self.mock_voice.voice_key = {'voice_id': 'casual_male'}
+        self.mock_voice.options = {
+            'model': {'default': 'voxtral-mini-tts-2603'},
+        }
+
+    def _mock_response(self, status_code, text='', headers=None, content=b''):
+        response = mock.Mock()
+        response.status_code = status_code
+        response.text = text
+        response.headers = headers or {}
+        response.content = content
+        return response
+
+    def test_mistral_rate_limit_429(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_rate_limit_429'
+        response = self._mock_response(429, 'Too Many Requests')
+        with mock.patch('requests.post', return_value=response):
+            with self.assertRaises(errors.RateLimitError) as ctx:
+                self.service.get_tts_audio('hello', self.mock_voice, {})
+            self.assertIsInstance(ctx.exception, errors.TransientError)
+            self.assertIn('429', str(ctx.exception))
+
+    def test_mistral_unauthorized_401(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_unauthorized_401'
+        response = self._mock_response(401, 'Unauthorized')
+        with mock.patch('requests.post', return_value=response):
+            with self.assertRaises(errors.ServicePermissionError) as ctx:
+                self.service.get_tts_audio('hello', self.mock_voice, {})
+            self.assertIsInstance(ctx.exception, errors.PermanentError)
+            self.assertIn('401', str(ctx.exception))
+
+    def test_mistral_forbidden_403(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_forbidden_403'
+        response = self._mock_response(403, 'Content policy violation')
+        with mock.patch('requests.post', return_value=response):
+            with self.assertRaises(errors.ServicePermissionError) as ctx:
+                self.service.get_tts_audio('hello', self.mock_voice, {})
+            self.assertIsInstance(ctx.exception, errors.PermanentError)
+            self.assertIn('403', str(ctx.exception))
+
+    def test_mistral_bad_request_400(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_bad_request_400'
+        response = self._mock_response(400, '{"error": "Invalid voice"}')
+        with mock.patch('requests.post', return_value=response):
+            with self.assertRaises(errors.ServiceInputError) as ctx:
+                self.service.get_tts_audio('hello', self.mock_voice, {})
+            self.assertIsInstance(ctx.exception, errors.PermanentError)
+            self.assertIn('400', str(ctx.exception))
+
+    def test_mistral_success_json_envelope(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_success_json_envelope'
+        audio_bytes = b'ID3-fake-mp3-payload'
+        payload = {'audio_data': base64.b64encode(audio_bytes).decode('ascii')}
+        response = self._mock_response(200, headers={'Content-Type': 'application/json'})
+        response.json = mock.Mock(return_value=payload)
+
+        with mock.patch('requests.post', return_value=response):
+            result = self.service.get_tts_audio('hello', self.mock_voice, {})
+
+        self.assertEqual(result, audio_bytes)
+
+    def test_mistral_success_raw_audio_response(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_success_raw_audio_response'
+        audio_bytes = b'ID3-fake-mp3-payload'
+        response = self._mock_response(
+            200, headers={'Content-Type': 'audio/mpeg'}, content=audio_bytes
+        )
+
+        with mock.patch('requests.post', return_value=response):
+            result = self.service.get_tts_audio('hello', self.mock_voice, {})
+
+        self.assertEqual(result, audio_bytes)
+
+    def test_mistral_unsupported_audio_format(self):
+        # pytest tests/test_tts_services/test_mistral.py -k 'test_mistral_unsupported_audio_format'
+        # ogg_opus must fail early; Mistral returns raw Opus (no Ogg container),
+        # which HyperTTS's audio verification cannot recognise.
+        with self.assertRaises(errors.ServiceInputError) as ctx:
+            self.service.get_tts_audio(
+                'hello',
+                self.mock_voice,
+                {options.AUDIO_FORMAT_PARAMETER: options.AudioFormat.ogg_opus.name},
+            )
+        self.assertIsInstance(ctx.exception, errors.PermanentError)


### PR DESCRIPTION
## Summary

Adds Mistral AI's **Voxtral** TTS as a new paid TTS service, following the same shape as the existing OpenAI/ElevenLabs integrations. Voxtral is Mistral's text-to-speech model announced March 2026 — see the [official API reference](https://docs.mistral.ai/api/endpoint/audio/speech) and [Voxtral announcement](https://mistral.ai/news/voxtral-tts/).

## What's added

| File | Change |
|---|---|
| `hypertts_addon/services/service_mistral.py` | New `Mistral(service.ServiceBase)` class. Auto-discovered by `ServiceManager` via the existing `service_*.py` scan — no registry changes needed. |
| `hypertts_addon/services/voicelist.py` | Appends the 20 preset voices documented in the Voxtral release. |
| `tests/test_tts_services/test_mistral.py` | `TestMistral` (live API, English + French) + `TestMistralErrorHandling` (7 offline mock tests covering every error branch and both response shapes). |
| `tests/test_tts_services/base.py` | Registers Mistral in `configure_service_manager` alongside the other paid services. |

## Voice inventory (20 voices, 9 languages)

| Language | Voice IDs |
|---|---|
| English (en_US) | `casual_male`, `casual_female`, `cheerful_female`, `neutral_male`, `neutral_female` |
| French (fr_FR) | `fr_male`, `fr_female` |
| Spanish (es_ES) | `es_male`, `es_female` |
| German (de_DE) | `de_male`, `de_female` |
| Italian (it_IT) | `it_male`, `it_female` |
| Portuguese (pt_PT) | `pt_male`, `pt_female` |
| Dutch (nl_NL) | `nl_male`, `nl_female` |
| Arabic (ar_XA) | `ar_male` |
| Hindi (hi_IN) | `hi_male`, `hi_female` |

## Implementation notes

- **Only `mp3` output is exposed.** Mistral supports mp3/wav/pcm/flac/opus, but returns *raw* Opus (no Ogg container) — HyperTTS's `verify_audio_output` matches against `Ogg data, Opus audio` magic bytes for `AudioFormat.ogg_opus`, so exposing `ogg_opus` would silently break the audio pipeline. Unsupported formats are rejected up-front as a `ServiceInputError` so batch retry stops immediately.
- **HTTP error mapping** matches the existing OpenAI service:
  - `400 → ServiceInputError` (permanent — mirrors the fix for Sentry `ANKI-HYPER-TTS-JRS` in `service_openai.py`)
  - `401 / 403 → ServicePermissionError` (403 is grouped with 401 because Mistral returns 403 for both invalid keys and moderated/rejected content — neither is retryable, per [their docs](https://docs.mistral.ai/studio-api/audio/text_to_speech/speech))
  - `429 → RateLimitError`
  - anything else → `raise_for_status()` (falls through to the generic `TransientError` handling in `ServiceManager`)
- **Response parsing is defensive.** The documented non-streaming response is a JSON envelope (`{"audio_data": "<base64>"}`), but the code also accepts raw audio bytes so it stays correct if Mistral changes the response shape.
- `cloudlanguagetools_enabled` returns `False` — this integration talks directly to `api.mistral.ai`, not via a CLT proxy.

## Testing

**Offline tests** (7, all passing locally on Python 3.12):

```
$ pytest tests/test_tts_services/test_mistral.py::TestMistralErrorHandling -v
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_bad_request_400 PASSED
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_forbidden_403 PASSED
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_rate_limit_429 PASSED
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_success_json_envelope PASSED
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_success_raw_audio_response PASSED
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_unauthorized_401 PASSED
tests/test_tts_services/test_mistral.py::TestMistralErrorHandling::test_mistral_unsupported_audio_format PASSED
7 passed
```

`tests/test_servicemanager.py` also still passes (10/10) — confirming auto-discovery picks up the new service without any registry edits.

**Live tests** (`TestMistral.test_mistral_english` and `test_mistral_french`) require `MISTRAL_API_KEY` and were not run in this branch — see below.

## ⚠️ CI action required

`tests/test_tts_services/base.py` now reads `os.environ['MISTRAL_API_KEY']` in `configure_service_manager`, matching the same pattern used for `OPENAI_API_KEY`, `AZURE_SERVICES_KEY`, etc. Before the live integration tests will run in CI, the `MISTRAL_API_KEY` secret needs to be added to the repository's actions/CI environment (a Mistral API key with TTS access — pricing is $0.016 per 1K characters per the [Mistral pricing page](https://mistral.ai/pricing/api/)).

## Not included in this PR

- No Cloud Language Tools proxy integration (would need a corresponding change on the CLT side).
- No custom voice cloning UI (Voxtral supports zero-shot cloning via `ref_audio`, but that's a separate feature — this PR only ships the 20 preset voices).
- No streaming support (Voxtral supports SSE streaming, not currently useful for HyperTTS's batch workflow).
